### PR TITLE
Changed definitions.yaml, 1.1.1.x were not executing

### DIFF
--- a/cfg/1.1.0/definitions.yaml
+++ b/cfg/1.1.0/definitions.yaml
@@ -10,252 +10,251 @@ groups:
   checks:
     - id: 1.1.1
       description: "Disable unused filesystems"
-      checks:
-      - id: 1.1.1.1.a
-        description: "Ensure mounting of cramfs filesystems is disabled"
-        audit: "modprobe -n -v cramfs"
-        tests:
-          test_items:
-          - flag: "install /bin/true"
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install cramfs /bin/true
-          Run the following command to unload the `cramfs` module:
-          # rmmod cramfs
-        scored: true
-      - id: 1.1.1.1.b
-        description: "Ensure mounting of cramfs filesystems is disabled"
-        audit: "lsmod | grep cramfs"
+    - id: 1.1.1.1.a
+      description: "Ensure mounting of cramfs filesystems is disabled"
+      audit: "modprobe -n -v cramfs"
+      tests:
+        test_items:
+        - flag: "install /bin/true"
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install cramfs /bin/true
+        Run the following command to unload the `cramfs` module:
+        # rmmod cramfs
+      scored: true
+    - id: 1.1.1.1.b
+      description: "Ensure mounting of cramfs filesystems is disabled"
+      audit: "lsmod | grep cramfs"
+      tests:
+        test_items:
+        - flag: ""
+          compare:
+            op: eq
+            value: ""
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install cramfs /bin/true
+        Run the following command to unload the `cramfs` module:
+        # rmmod cramfs
+      scored: true
+    - id: 1.1.1.2.a
+      description: "Ensure mounting of freevxfs filesystems is disabled"
+      audit: "modprobe -n -v freevxfs"
+      tests:
+        test_items:
+        - flag: "install /bin/true"
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install freevxfs /bin/true
+        Run the following command to unload the `freevxfs` module:
+        # rmmod freevxfs
+      scored: true
+    - id: 1.1.1.2.b
+      description: "Ensure mounting of freevxfs filesystems is disabled"
+      audit: "lsmod | grep freevxfs"
+      tests:
+        test_items:
+        - flag: ""
+          compare:
+            op: eq
+            value: ""
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install freevxfs /bin/true
+        Run the following command to unload the `freevxfs` module:
+        # rmmod freevxfs
+      scored: true
+    - id: 1.1.1.3.a
+      description: "Ensure mounting of jffs2 filesystems is disabled"
+      audit: "modprobe -n -v jffs2"
+      tests:
+        test_items:
+        - flag: "install /bin/true"
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install jffs2 /bin/true
+        Run the following command to unload the `jffs2` module:
+        # rmmod jffs2
+      scored: true
+    - id: 1.1.1.3.b
+      description: "Ensure mounting of jffs2 filesystems is disabled"
+      audit: "lsmod | grep jffs2"
+      tests:
+        test_items:
+        - flag: ""
+          compare:
+            op: eq
+            value: ""
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install jffs2 /bin/true
+        Run the following command to unload the `jffs2` module:
+        # rmmod jffs2
+      scored: true
+    - id: 1.1.1.4.a
+      description: "Ensure mounting of hfs filesystems is disabled"
+      audit: "modprobe -n -v hfs"
+      tests:
+        test_items:
+        - flag: "install /bin/true"
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install hfs /bin/true
+        Run the following command to unload the `hfs` module:
+        # rmmod hfs
+      scored: true
+    - id: 1.1.1.4.b
+      description: "Ensure mounting of hfs filesystems is disabled"
+      audit: "lsmod | grep hfs"
+      tests:
+        test_items:
+        - flag: ""
+          compare:
+            op: eq
+            value: ""
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install hfs /bin/true
+        Run the following command to unload the `hfs` module:
+        # rmmod hfs
+      scored: true
+    - id: 1.1.1.5.a
+      description: "Ensure mounting of hfsplus filesystems is disabled"
+      audit: "modprobe -n -v hfsplus"
+      tests:
+        test_items:
+        - flag: "install /bin/true"
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install hfsplus /bin/true
+        Run the following command to unload the `hfsplus` module:
+        # rmmod hfsplus
+      scored: true
+    - id: 1.1.1.5.b
+      description: "Ensure mounting of hfsplus filesystems is disabled"
+      audit: "lsmod | grep hfsplus"
+      tests:
+        test_items:
+        - flag: ""
+          compare:
+            op: eq
+            value: ""
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install hfsplus /bin/true
+        Run the following command to unload the `hfsplus` module:
+        # rmmod hfsplus
+      scored: true
+    - id: 1.1.1.6.a
+      description: "Ensure mounting of squashfs filesystems is disabled"
+      sub_checks:
+      - check:
+          audit: "modprobe -n -v squashfs"
+          constraints:
+            platform:
+            - rhel7
+          tests:
+            test_items:
+            - flag: "install /bin/true"
+              set: true
+          remediation: |
+            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+            install squashfs /bin/true
+            Run the following command to unload the `squashfs` module:
+            # rmmod squashfs
+      scored: true
+    - id: 1.1.1.6.b
+      description: "Ensure mounting of squashfs filesystems is disabled"
+      sub_checks:
+      - check:
+          audit: "lsmod | grep squashfs"
+          constraints:
+            platform:
+            - rhel7
+          tests:
+            test_items:
+            - flag: ""
+              set: true
+          remediation: |
+            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+            install squashfs /bin/true
+            Run the following command to unload the `squashfs` module:
+            # rmmod squashfs
+      scored: true
+    - id: 1.1.1.7.a
+      description: "Ensure mounting of udf filesystems is disabled"
+      audit: "modprobe -n -v udf"
+      tests:
+        test_items:
+        - flag: "install /bin/true"
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install udf /bin/true
+        Run the following command to unload the `udf` module:
+        # rmmod udf
+      scored: true
+    - id: 1.1.1.7.b
+      description: "Ensure mounting of udf filesystems is disabled"
+      audit: "lsmod | grep udf"
+      tests:
+        test_items:
+        - flag: ""
+          compare:
+            op: eq
+            value: ""
+          set: true
+      remediation: |
+        Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+        install udf /bin/true
+        Run the following command to unload the `udf` module:
+        # rmmod udf
+      scored: true
+    - id: 1.1.1.8.a
+      description: "Ensure mounting of FAT filesystems is disabled"
+      sub_checks:
+      - check:
+          audit: "modprobe -n -v vfat"
+          constraints:
+            platform:
+            - rhel7
+          tests:
+            test_items:
+            - flag: "install /bin/true"
+              set: true
+          remediation: |
+            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+            install vfat /bin/true
+            Run the following command to unload the `vfat` module:
+            # rmmod vfat
+      scored: true
+    - id: 1.1.1.8.b
+      description: "Ensure mounting of FAT filesystems is disabled"
+      sub_checks:
+      - check:
+        audit: "lsmod | grep vfat"
+        constraints:
+          platform:
+          - rhel7
         tests:
           test_items:
           - flag: ""
-            compare:
-              op: eq
-              value: ""
             set: true
         remediation: |
           Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install cramfs /bin/true
-          Run the following command to unload the `cramfs` module:
-          # rmmod cramfs
-        scored: true
-      - id: 1.1.1.2.a
-        description: "Ensure mounting of freevxfs filesystems is disabled"
-        audit: "modprobe -n -v freevxfs"
-        tests:
-          test_items:
-          - flag: "install /bin/true"
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install freevxfs /bin/true
-          Run the following command to unload the `freevxfs` module:
-          # rmmod freevxfs
-        scored: true
-      - id: 1.1.1.2.b
-        description: "Ensure mounting of freevxfs filesystems is disabled"
-        audit: "lsmod | grep freevxfs"
-        tests:
-          test_items:
-          - flag: ""
-            compare:
-              op: eq
-              value: ""
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install freevxfs /bin/true
-          Run the following command to unload the `freevxfs` module:
-          # rmmod freevxfs
-        scored: true
-      - id: 1.1.1.3.a
-        description: "Ensure mounting of jffs2 filesystems is disabled"
-        audit: "modprobe -n -v jffs2"
-        tests:
-          test_items:
-          - flag: "install /bin/true"
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install jffs2 /bin/true
-          Run the following command to unload the `jffs2` module:
-          # rmmod jffs2
-        scored: true
-      - id: 1.1.1.3.b
-        description: "Ensure mounting of jffs2 filesystems is disabled"
-        audit: "lsmod | grep jffs2"
-        tests:
-          test_items:
-          - flag: ""
-            compare:
-              op: eq
-              value: ""
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install jffs2 /bin/true
-          Run the following command to unload the `jffs2` module:
-          # rmmod jffs2
-        scored: true
-      - id: 1.1.1.4.a
-        description: "Ensure mounting of hfs filesystems is disabled"
-        audit: "modprobe -n -v hfs"
-        tests:
-          test_items:
-          - flag: "install /bin/true"
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install hfs /bin/true
-          Run the following command to unload the `hfs` module:
-          # rmmod hfs
-        scored: true
-      - id: 1.1.1.4.b
-        description: "Ensure mounting of hfs filesystems is disabled"
-        audit: "lsmod | grep hfs"
-        tests:
-          test_items:
-          - flag: ""
-            compare:
-              op: eq
-              value: ""
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install hfs /bin/true
-          Run the following command to unload the `hfs` module:
-          # rmmod hfs
-        scored: true
-      - id: 1.1.1.5.a
-        description: "Ensure mounting of hfsplus filesystems is disabled"
-        audit: "modprobe -n -v hfsplus"
-        tests:
-          test_items:
-          - flag: "install /bin/true"
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install hfsplus /bin/true
-          Run the following command to unload the `hfsplus` module:
-          # rmmod hfsplus
-        scored: true
-      - id: 1.1.1.5.b
-        description: "Ensure mounting of hfsplus filesystems is disabled"
-        audit: "lsmod | grep hfsplus"
-        tests:
-          test_items:
-          - flag: ""
-            compare:
-              op: eq
-              value: ""
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install hfsplus /bin/true
-          Run the following command to unload the `hfsplus` module:
-          # rmmod hfsplus
-        scored: true
-      - id: 1.1.1.6.a
-        description: "Ensure mounting of squashfs filesystems is disabled"
-        sub_checks:
-        - check:
-            audit: "modprobe -n -v squashfs"
-            constraints:
-              platform:
-              - rhel7
-            tests:
-              test_items:
-              - flag: "install /bin/true"
-                set: true
-            remediation: |
-              Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-              install squashfs /bin/true
-              Run the following command to unload the `squashfs` module:
-              # rmmod squashfs
-        scored: true
-      - id: 1.1.1.6.b
-        description: "Ensure mounting of squashfs filesystems is disabled"
-        sub_checks:
-        - check:
-            audit: "lsmod | grep squashfs"
-            constraints:
-              platform:
-              - rhel7
-            tests:
-              test_items:
-              - flag: ""
-                set: true
-            remediation: |
-              Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-              install squashfs /bin/true
-              Run the following command to unload the `squashfs` module:
-              # rmmod squashfs
-        scored: true
-      - id: 1.1.1.7.a
-        description: "Ensure mounting of udf filesystems is disabled"
-        audit: "modprobe -n -v udf"
-        tests:
-          test_items:
-          - flag: "install /bin/true"
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install udf /bin/true
-          Run the following command to unload the `udf` module:
-          # rmmod udf
-        scored: true
-      - id: 1.1.1.7.b
-        description: "Ensure mounting of udf filesystems is disabled"
-        audit: "lsmod | grep udf"
-        tests:
-          test_items:
-          - flag: ""
-            compare:
-              op: eq
-              value: ""
-            set: true
-        remediation: |
-          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-          install udf /bin/true
-          Run the following command to unload the `udf` module:
-          # rmmod udf
-        scored: true
-      - id: 1.1.1.8.a
-        description: "Ensure mounting of FAT filesystems is disabled"
-        sub_checks:
-        - check:
-            audit: "modprobe -n -v vfat"
-            constraints:
-              platform:
-              - rhel7
-            tests:
-              test_items:
-              - flag: "install /bin/true"
-                set: true
-            remediation: |
-              Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-              install vfat /bin/true
-              Run the following command to unload the `vfat` module:
-              # rmmod vfat
-        scored: true
-      - id: 1.1.1.8.b
-        description: "Ensure mounting of FAT filesystems is disabled"
-        sub_checks:
-        - check:
-            audit: "lsmod | grep vfat"
-            constraints:
-              platform:
-              - rhel7
-            tests:
-              test_items:
-              - flag: ""
-                set: true
-            remediation: |
-              Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-              install vfat /bin/true
-              Run the following command to unload the `vfat` module:
-              # rmmod vfat
+          install vfat /bin/true
+          Run the following command to unload the `vfat` module:
+          # rmmod vfat
         scored: true
     - id: 1.1.2
       description: "Ensure separate partition exists for /tmp"


### PR DESCRIPTION
1.1.1.x tests were not executing. 
The problem was that they were indented to be under the 1.1.1
The hierarchy was not working. so now they are the same indentation as 1.1.1 test. 