### PR TITLE
Update README.md - make some headings into bullet points

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Tests are configured with YAML files, making this tool easy to update as test sp
 linux-bench currently supports tests for benchmark version 1.1.0 only.
 
 linux-bench will determine the test set to run on the host machine based on the following:
-##### Operating system platform - ubuntu/debian/rhel/coreos
-##### Boot loader - grub/grub2
-##### System logging tool - rsyslog/syslog-ng
-##### Lsm - selinux/apparmor
+- **Operating system platform - ubuntu/debian/rhel/coreos**
+- **Boot loader - grub/grub2**
+- **System logging tool - rsyslog/syslog-ng**
+- **Lsm - selinux/apparmor**
 
 
 ## Installation


### PR DESCRIPTION
Converted identifying requirements to bullet points rather than plain lines, owing to better comprehensibility.
Changed \####\ to ** ** - Because it makes sense to bolden the bullet points, rather than declaring them as headers