### PR TITLE
removed deprecated field in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 ---
 language: go
 
-sudo: required
-
 notifications:
   email: false
 


### PR DESCRIPTION
Refer to https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.

> In the next phase of the migration, all builds will run on virtual-machine-based infrastructure – regardless of the configuration for `sudo` in the `.travis.yml`.

> Soon we will run all projects on the virtual-machine-based infrastructure, the sudo keyword will be fully deprecated.