### PR TITLE
Remove duplicate test IDs

### DIFF
--- a/cfg/1.1.0/definitions.yaml
+++ b/cfg/1.1.0/definitions.yaml
@@ -5995,7 +5995,7 @@ groups:
             
       scored: true                  
             
-    - id: 4.1.9.a
+    - id: 4.1.9.c
       description: "Ensure session initiation information is collected"
       audit: "grep logins /etc/audit/audit.rules"   
       tests:
@@ -6013,7 +6013,7 @@ groups:
             
       scored: true                  
             
-    - id: 4.1.9.b
+    - id: 4.1.9.d
       description: "Ensure session initiation information is collected"
       audit: "auditctl -l | grep logins"   
       tests:


### PR DESCRIPTION
Fix for https://github.com/aquasecurity/linux-bench/issues/45:

 There are two tests with the ID `4.1.9.a` and `4.1.9.b` in `cfg/1.1.0/definitions.yaml`. These tests are distinct, and should have unique IDs.