### PR TITLE
Fix 1.1.2

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -306,8 +306,11 @@ groups:
       audit: "mount | grep -E '\\s/tmp\\s'"   
       tests:
         test_items:
-        - flag: "tmpfs on /tmp type tmpfs"
-          set: true                        
+        - flag: ""
+          compare:
+            op: eq          
+            value: ""
+          set: false                        
       remediation: |
             Configure /etc/fstab as appropriate.
             example: 


### PR DESCRIPTION
fix issue https://github.com/aquasecurity/linux-bench/issues/48
The flag value was wrong, now changed it to be "not empty" because as we look at the CIS test, this is what we check in the test 

> Run the following command and verify output shows /tmp is mounted:
so if the audit command return any output it means /tmp is mounted. 