### PR TITLE
.goreleaser.yml: Provide arm/arm64 builds too

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,12 +8,18 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
     ldflags:
      - "-X github.com/aquasecurity/linux-bench/root.cfgDir={{.Env.LINUXBENCH_CFG}}"
 # Archive customization
 archives:
   - id: compress
     format: tar.gz
+    name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{.Arm }}{{ end }}'
     files:
       - "cfg/**/*"
 nfpms:


### PR DESCRIPTION
This would allow to get arm/arm64 binaries on the next github release as well.
