### PR TITLE
Make unit tests work under GitHub Actions

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -5,14 +5,9 @@ import (
 	"testing"
 )
 
-var (
-	cfgdir = "./cfg"
-	ver    = "1.1.0"
-)
-
 // Tests all standard linux-bench defintion files
 func TestGetDefinitionFilePath(t *testing.T) {
-	d, err := os.Open(cfgdir)
+	d, err := os.Open("./cfg")
 	if err != nil {
 		t.Errorf("unexpected error: %s\n", err)
 	}
@@ -23,6 +18,7 @@ func TestGetDefinitionFilePath(t *testing.T) {
 	}
 
 	for _, ver := range vers {
+		t.Logf("%v", ver)
 		_, err := getDefinitionFilePath(ver)
 		if err != nil {
 			t.Errorf("unexpected error: %s\n", err)
@@ -31,7 +27,8 @@ func TestGetDefinitionFilePath(t *testing.T) {
 }
 
 func TestRunControls(t *testing.T) {
-	path, err := getDefinitionFilePath(ver)
+	cfgDir = "./hack"
+	path, err := getDefinitionFilePath("test-definitions")
 	if err != nil {
 		t.Errorf("unexpected error: %s\n", err)
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -8,7 +8,6 @@ import (
 var (
 	cfgdir = "./cfg"
 	ver    = "1.1.0"
-	path   string
 )
 
 // Tests all standard linux-bench defintion files
@@ -31,20 +30,12 @@ func TestGetDefinitionFilePath(t *testing.T) {
 	}
 }
 
-func TestGetControls(t *testing.T) {
-	var err error
-	path, err = getDefinitionFilePath(ver)
-	if err != nil {
-		t.Errorf("unexpected error: %s\n", err)
-	}
-
-	_, err = getControls(path, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %s\n", err)
-	}
-}
-
 func TestRunControls(t *testing.T) {
+	path, err := getDefinitionFilePath(ver)
+	if err != nil {
+		t.Errorf("unexpected error: %s\n", err)
+	}
+
 	control, err := getControls(path, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %s\n", err)

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -2,7020 +2,6987 @@
 controls:
 version: 2.0.0
 id: 1
-description: "Initial Setup"  
+description: "Initial Setup"
 type: "master"
 groups:
-- id: 1.1
-  description: "Filesystem Configuration"
-  checks:
-    - id: 1.1.1
-      description: "Disable unused filesystems"
-      checks:
-    - id: 1.1.1.1.a
-      description: "Ensure mounting of cramfs filesystems is disabled"
-      audit: "modprobe -n -v cramfs"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/cramfs.conf
-        and add the following line:
-        install cramfs /bin/true
-        Run the following command to unload the cramfs module: 
-        # rmmod cramfs
-      scored: true
-    - id: 1.1.1.1.b
-      description: "Ensure mounting of cramfs filesystems is disabled"
-      audit: "lsmod | grep cramfs"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/cramfs.conf
-        and add the following line:
-        install cramfs /bin/true
-        Run the following command to unload the cramfs module: 
-        # rmmod cramfs
-      scored: true
-    - id: 1.1.1.2.a
-      description: "Ensure mounting of freevxfs filesystems is disabled"
-      audit: "modprobe -n -v freevxfs"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/freevxfs.conf
-        and add the following line:
-        install freevxfs /bin/true
-        Run the following command to unload the freevxfs module:
-        # rmmod freevxfs
-      scored: true
-    - id: 1.1.1.2.b
-      description: "Ensure mounting of freevxfs filesystems is disabled"
-      audit: "lsmod | grep freevxfs"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/freevxfs.conf
-        and add the following line:
-        install freevxfs /bin/true
-        Run the following command to unload the freevxfs module:
-        # rmmod freevxfs
-      scored: true
-    - id: 1.1.1.3.a
-      description: "Ensure mounting of jffs2 filesystems is disabled"
-      audit: "modprobe -n -v jffs2"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/jffs2.conf
-        and add the following line:
-        install jffs2 /bin/true
-        Run the following command to unload the jffs2 module:
-        # rmmod jffs2
-      scored: true
-    - id: 1.1.1.3.b
-      description: "Ensure mounting of jffs2 filesystems is disabled"
-      audit: "lsmod | grep jffs2"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/jffs2.conf
-        and add the following line:
-        install jffs2 /bin/true
-        Run the following command to unload the jffs2 module:
-        # rmmod jffs2
-      scored: true
-    - id: 1.1.1.4.a
-      description: "Ensure mounting of hfs filesystems is disabled"
-      audit: "modprobe -n -v hfs"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/hfs.conf
-        and add the following line:
-        install hfs /bin/true
-        Run the following command to unload the hfs module:
-        # rmmod hfs
-      scored: true
-    - id: 1.1.1.4.b
-      description: "Ensure mounting of hfs filesystems is disabled"
-      audit: "lsmod | grep hfs"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/hfs.conf
-        and add the following line:
-        install hfs /bin/true
-        Run the following command to unload the hfs module:
-        # rmmod hfs
-      scored: true
-    - id: 1.1.1.5.a
-      description: "Ensure mounting of hfsplus filesystems is disabled"
-      audit: "modprobe -n -v hfsplus"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/hfsplus.conf
-        and add the following line:
-        install hfsplus /bin/true
-        Run the following command to unload the hfsplus module:
-        # rmmod hfsplus
-      scored: true
-    - id: 1.1.1.5.b
-      description: "Ensure mounting of hfsplus filesystems is disabled"
-      audit: "lsmod | grep hfsplus"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/hfsplus.conf
-        and add the following line:
-        install hfsplus /bin/true
-        Run the following command to unload the hfsplus module:
-        # rmmod hfsplus
-      scored: true
-    - id: 1.1.1.6.a
-      description: "Ensure mounting of squashfs filesystems is disabled"
-      sub_checks:
-      - check:
-          audit: "modprobe -n -v squashfs"
-          constraints:
-            platform:
-            - rhel7
-          tests:
-            test_items:
+  - id: 1.1
+    description: "Filesystem Configuration"
+    checks:
+      - id: 1.1.1
+        description: "Disable unused filesystems"
+        checks:
+      - id: 1.1.1.1.a
+        description: "Ensure mounting of cramfs filesystems is disabled"
+        audit: "modprobe -n -v cramfs"
+        tests:
+          test_items:
             - flag: "install /bin/true"
               set: true
-          remediation: |
-            Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-            Example: vim /etc/modprobe.d/squashfs.conf
-            and add the following line:
-            install squashfs /bin/true
-            Run the following command to unload the squashfs module: 
-            # rmmod squashfs
-      scored: true
-    - id: 1.1.1.6.b
-      description: "Ensure mounting of squashfs filesystems is disabled"
-      sub_checks:
-      - check:
-          audit: "lsmod | grep squashfs"
-          constraints:
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: ""
-              set: true
-          remediation: |
-            Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-            Example: vim /etc/modprobe.d/squashfs.conf
-            and add the following line:
-            install squashfs /bin/true
-            Run the following command to unload the squashfs module: 
-            # rmmod squashfs  
-      scored: true
-    - id: 1.1.1.7.a
-      description: "Ensure mounting of udf filesystems is disabled"
-      audit: "modprobe -n -v udf"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf 
-        Example: vim /etc/modprobe.d/udf.conf
-        and add the following line: install udf /bin/true
-        Run the following command to unload the udf module: 
-        # rmmod udf
-      scored: true
-    - id: 1.1.1.7.b
-      description: "Ensure mounting of udf filesystems is disabled"
-      audit: "lsmod | grep udf"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf 
-        Example: vim /etc/modprobe.d/udf.conf
-        and add the following line: install udf /bin/true
-        Run the following command to unload the udf module: 
-        # rmmod udf
-      scored: true
-    - id: 1.1.1.8.a
-      description: "Ensure mounting of FAT filesystems is disabled"
-      sub_checks:
-      - check:
-          audit: "grep -i vfat /etc/fstab"
-          constraints:
-            platform:
-            - rhel7
-          type: manual
-          remediation: |
-            Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-            Example: vim /etc/modprobe.d/vfat.conf
-            install vfat /bin/true
-            Run the following command to unload the vfat module: 
-            # rmmod vfat
-      scored: false
-    - id: 1.1.1.8.b
-      description: "Ensure mounting of FAT filesystems is disabled"
-      sub_checks:
-      - check:
-          audit: "modprobe -n -v vfat"
-          constraints:
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "install /bin/true"
-              set: true
-          remediation: |
-            Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-            Example: vim /etc/modprobe.d/vfat.conf
-            install vfat /bin/true
-            Run the following command to unload the vfat module: 
-            # rmmod vfat
-      scored: false
-    - id: 1.1.1.8.c
-      description: "Ensure mounting of FAT filesystems is disabled"
-      sub_checks:
-      - check:
-          audit: "lsmod | grep vfat"
-          constraints:
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: ""
-              set: true
-          remediation: |
-            Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-            Example: vim /etc/modprobe.d/vfat.conf
-            install vfat /bin/true
-            Run the following command to unload the vfat module: 
-            # rmmod vfat
-      scored: false
-    - id: 1.1.2.a
-      description: "Ensure /tmp is configured"
-      audit: "mount | grep -E '\\s/tmp\\s'"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq          
-            value: ""
-          set: false                        
-      remediation: |
-            Configure /etc/fstab as appropriate.
-            example: 
-            tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0
-            OR 
-            Run the following commands to enable systemd /tmp mounting: 
-            systemctl unmask tmp.mount systemctl enable tmp.mount
-            Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount: 
-            [Mount] 
-            What=tmpfs 
-            Where=/tmp 
-            Type=tmpfs 
-            Options=mode=1777,strictatime,noexec,nodev,nosuid
-      scored: true
-    - id: 1.1.2.b
-      description: "Ensure /tmp is configured"
-      audit: "grep -E '\\s/tmp\\s' /etc/fstab | grep -E -v '^\\s*#'"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq          
-            value: ""
-          set: false                      
-      remediation: |
-            Configure /etc/fstab as appropriate.
-            example: 
-            tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0
-            OR 
-            Run the following commands to enable systemd /tmp mounting: 
-            systemctl unmask tmp.mount systemctl enable tmp.mount
-            Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount: 
-            [Mount] 
-            What=tmpfs 
-            Where=/tmp 
-            Type=tmpfs 
-            Options=mode=1777,strictatime,noexec,nodev,nosuid
-      scored: true
-    - id: 1.1.3
-      description: "Ensure nodev option set on /tmp partition"
-      audit: "mount | grep -E '\\s/tmp\\s' | grep -v nodev"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition.
-            See the fstab(5) manual page for more information. 
-            Run the following command to remount /tmp :
-            # mount -o remount,nodev /tmp
-            or 
-            Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp mount options:
-            [Mount] 
-            Options=mode=1777,strictatime,noexec,nodev,nosuid
-            un the following command to remount /tmp :
-            # mount -o remount,nodev /tmp
-      scored: true                  
-             
-            
-    - id: 1.1.4
-      description: "Ensure nosuid option set on /tmp partition"
-      audit: "mount | grep -E '\\s/tmp\\s' | grep -v nosuid"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp 
-            partition. See the fstab(5) manual page for more information. 
-            Run the following command to remount /tmp : 
-            # mount -o remount,nosuid /tmp
-            or 
-            Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp mount options: 
-            [Mount] 
-            Options=mode=1777,strictatime,noexec,nodev,nosuid
-            Run the following command to remount /tmp : 
-            # mount -o remount,nosuid /tmp
-      scored: true                  
-                      
-            
-    - id: 1.1.5
-      description: "Ensure noexec option set on /tmp partition"
-      audit: "mount | grep -E '\\s/tmp\\s' | grep -v noexec"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Edit the `/etc/fstab` file and add `noexec` to the fourth field (mounting options) for the `/tmp` partition. See the `fstab(5)` manual page for more information.
-                        Run the following command to remount `/tmp` :
-            
-            # mount -o remount,noexec /tmp
-            
-      scored: true                  
-            
-    - id: 1.1.6
-      description: "Ensure separate partition exists for /var"
-      audit: "mount | grep -E '\\s/var\\s'"   
-      tests:
-        test_items:
-        - flag: "/dev/xvdg1 on /var type ext4 (rw,relatime,data=ordered)"
-          set: true                        
-      remediation: |
-            For new installations, during installation create a custom partition setup and specify a separate partition for `/var` .
-            For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
-      scored: true 
-    - id: 1.1.7
-      description: "Ensure separate partition exists for /var/tmp"
-      audit: "mount | grep /var/tmp"   
-      tests:
-        test_items:
-        - flag: " on /var/tmp type ext4 (rw,nosuid,nodev,noexec,relatime)"
-          set: true                        
-      remediation: |
-            For new installations, during installation create a custom partition setup and specify a separate partition for `/var/tmp` .
-            For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
-      scored: true
-    - id: 1.1.8
-      description: "Ensure nodev option set on /var/tmp partition"
-      audit: "mount | grep -E '\\s/var/tmp\\s' | grep -v nodev"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true 
-      remediation: |
-            Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the 
-            /var/tmp partition. See the fstab(5) manual page for more information. 
-            Run the following command to remount /var/tmp : 
-            # mount -o remount,nodev /var/tmp
-            
-      scored: true                  
-               
-            
-    - id: 1.1.9
-      description: "Ensure nosuid option set on /var/tmp partition"
-      audit: "mount | grep -E '\\s/var/tmp\\s' | grep -v nosuid"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true 
-      remediation: |
-            Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the 
-            /var/tmp partition. See the fstab(5) manual page for more information. 
-            Run the following command to remount /var/tmp : 
-            # mount -o remount,nosuid /var/tmp
-            
-      scored: true
-    - id: 1.1.10
-      description: "Ensure noexec option set on /var/tmp partition"
-      audit: "mount | grep -E '\\s/var/tmp\\s' | grep -v noexec"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true 
-      remediation: |
-            Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the 
-            /var/tmp partition. See the fstab(5) manual page for more information. 
-            Run the following command to remount /var/tmp : 
-            # mount -o remount,noexec /var/tmp
-      scored: true
-    - id: 1.1.11
-      description: "Ensure separate partition exists for /var/log"
-      audit: "mount | grep /var/log"   
-      tests:
-        test_items:
-        - flag: "/dev/xvdh1 on /var/log type ext4 (rw,relatime,data=ordered)"
-          set: true                        
-      remediation: |
-            For new installations, during installation create a custom partition setup and specify a separate partition for `/var/log` .
-            For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
-      scored: true                                          
-    - id: 1.1.12
-      description: "Ensure separate partition exists for /var/log/audit"
-      audit: "mount | grep /var/log/audit"   
-      tests:
-        test_items:
-        - flag: "/dev/xvdi1 on /var/log/audit type ext4 (rw,relatime,data=ordered)"
-          set: true                        
-      remediation: |
-            For new installations, during installation create a custom partition setup and specify a separate partition for `/var/log/audit` .
-            For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
-      scored: true      
-    - id: 1.1.13
-      description: "Ensure separate partition exists for /home"
-      audit: "mount | grep /home"   
-      tests:
-        test_items:
-        - flag: "/dev/xvdf1 on /home type ext4 (rw,nodev,relatime,data=ordered)"
-          set: true                        
-      remediation: |
-            For new installations, during installation create a custom partition setup and specify a separate partition for `/home` .
-            For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
-      scored: true
-    - id: 1.1.14
-      description: "Ensure nodev option set on /home partition"
-      audit: "mount | grep -E '\\s/home\\s' | grep -v nodev"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true 
-      remediation: |
-            Edit the `/etc/fstab` file and add `nodev` to the fourth field (mounting options) for the `/home`
-            partition. See the `fstab(5)` manual page for more information.
-            
-            # mount -o remount,nodev /home
-            
-      scored: true                  
-      
-    - id: 1.1.15
-      description: "Ensure nodev option set on /dev/shm partition"
-      audit: "mount | grep -E '\\s/dev/shm\\s' | grep -v nodev"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true 
-      remediation: |
-            Edit the `/etc/fstab` file and add `nodev` to the fourth field (mounting options) for the `/dev/shm` partition. 
-            See the `fstab(5)` manual page for more information.
-            Run the following command to remount `/dev/shm` :
-            
-            # mount -o remount,nodev /dev/shm
-            
-      scored: true                  
-                          
-            
-    - id: 1.1.16
-      description: "Ensure nosuid option set on /dev/shm partition"
-      audit: "mount | grep -E '\\s/dev/shm\\s' | grep -v nosuid"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                         
-      remediation: |
-            Edit the `/etc/fstab` file and add `nosuid` to the fourth field (mounting options) for the `/dev/shm` partition.
-            See the `fstab(5)` manual page for more information.
-            Run the following command to remount `/dev/shm` :
-            
-            # mount -o remount,nosuid /dev/shm
-            
-      scored: true                  
-
-    - id: 1.1.17
-      description: "Ensure noexec option set on /dev/shm partition"
-      audit: "mount | grep -E '\\s/dev/shm\\s' | grep -v noexec"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true 
-      remediation: |
-            Edit the `/etc/fstab` file and add `noexec` to the fourth field (mounting options) for the `/dev/shm` partition.
-            See the `fstab(5)` manual page for more information.
-            Run the following command to remount `/dev/shm` :
-            
-            # mount -o remount,noexec /dev/shm
-            
-      scored: true                  
-            
-    - id: 1.1.18
-      description: "Ensure nodev option set on removable media partitions"
-      audit: "mount" 
-      type: manual      
-      remediation: |
-            Edit the `/etc/fstab` file and add `nodev` to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the `fstab(5)` manual page for more information.
-      scored: false    
-      
-    - id: 1.1.19
-      description: "Ensure nosuid option set on removable media partitions"
-      audit: "mount"   
-      type: manual       
-      remediation: |
-            Edit the `/etc/fstab` file and add `nosuid` to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the `fstab(5)` manual page for more information.
-      scored: false                  
-            
-    - id: 1.1.20
-      description: "Ensure noexec option set on removable media partitions"
-      audit: "mount"   
-      type: manual         
-      remediation: |
-            Edit the `/etc/fstab` file and add `noexec` to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the `fstab(5)` manual page for more information.
-      scored: false                  
-            
-    - id: 1.1.21
-      description: "Ensure sticky bit is set on all world-writable directories"
-      audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null | head -n 100"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Run the following command to set the sticky bit on all world writable directories:
-            # df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null | xargs -I '{}' chmod a+t '{}'
-            
-      scored: true                  
-           
-    - id: 1.1.22
-      description: "Disable Automounting"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list autofs"   
-          constraints: 
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "autofs 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `autofs` :
-                
-                # chkconfig autofs off
-                
-                
-                # systemctl disable autofs
-                
-                
-                # update-rc.d autofs disable     
-      - check:
-          audit: "systemctl is-enabled autofs"   
-          constraints: 
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "disabled"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `autofs` :
-                
-                # chkconfig autofs off
-                
-                
-                # systemctl disable autofs
-                
-                
-                # update-rc.d autofs disable  
-      - check:
-          audit: "ls /etc/rc*.d | grep autofs"   
-          constraints: 
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/cramfs.conf
+          and add the following line:
+          install cramfs /bin/true
+          Run the following command to unload the cramfs module:
+          # rmmod cramfs
+        scored: true
+      - id: 1.1.1.1.b
+        description: "Ensure mounting of cramfs filesystems is disabled"
+        audit: "lsmod | grep cramfs"
+        tests:
+          test_items:
             - flag: ""
               compare:
                 op: eq
                 value: ""
               set: true
-          remediation: |
-                Run one of the following commands to disable `autofs` :
-                
-                # chkconfig autofs off
-                
-                
-                # systemctl disable autofs
-                
-                
-                # update-rc.d autofs disable  
-      scored: true
-    - id: 1.1.23.a
-      description: "Disable USB Storage"
-      audit: "modprobe -n -v usb-storage"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/usb-storage.conf
-        and add the following line:
-        install usb-storage /bin/true
-        Run the following command to unload the usb-storage module:
-        # rmmod usb-storage
-      scored: true
-    - id: 1.1.23.b
-      description: "Disable USB Storage"
-      audit: "lsmod | grep usb-storage"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-        Example: vim /etc/modprobe.d/usb-storage.conf
-        and add the following line:
-        install usb-storage /bin/true
-        Run the following command to unload the usb-storage module:
-        # rmmod usb-storage
-      scored: true
-- id: 1.2
-  description: "Configure Software Updates"
-  checks:
-    - id: 1.2.1
-      description: "Ensure package manager repositories are configured"
-      sub_checks:
-      - check:
-          audit: "yum repo-list"
-          constraints:
-            platform:
-            - rhel7
-          type: manual
-          remediation: |
-                Configure your package manager repositories according to site policy.
-      - check:
-          audit: "apt-cache policy"
-          constraints:
-            platform:
-            - ubuntu16
-            - ubuntu18
-          type: manual
-          remediation: |
-                Configure your package manager repositories according to site policy.
-      - check:
-          audit: "zypper repos"
-          constraints:
-            platform:
-            - opensuse
-          type: manual
-          remediation: |
-                Configure your package manager repositories according to site policy.
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/cramfs.conf
+          and add the following line:
+          install cramfs /bin/true
+          Run the following command to unload the cramfs module:
+          # rmmod cramfs
+        scored: true
+      - id: 1.1.1.2.a
+        description: "Ensure mounting of freevxfs filesystems is disabled"
+        audit: "modprobe -n -v freevxfs"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/freevxfs.conf
+          and add the following line:
+          install freevxfs /bin/true
+          Run the following command to unload the freevxfs module:
+          # rmmod freevxfs
+        scored: true
+      - id: 1.1.1.2.b
+        description: "Ensure mounting of freevxfs filesystems is disabled"
+        audit: "lsmod | grep freevxfs"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/freevxfs.conf
+          and add the following line:
+          install freevxfs /bin/true
+          Run the following command to unload the freevxfs module:
+          # rmmod freevxfs
+        scored: true
+      - id: 1.1.1.3.a
+        description: "Ensure mounting of jffs2 filesystems is disabled"
+        audit: "modprobe -n -v jffs2"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/jffs2.conf
+          and add the following line:
+          install jffs2 /bin/true
+          Run the following command to unload the jffs2 module:
+          # rmmod jffs2
+        scored: true
+      - id: 1.1.1.3.b
+        description: "Ensure mounting of jffs2 filesystems is disabled"
+        audit: "lsmod | grep jffs2"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/jffs2.conf
+          and add the following line:
+          install jffs2 /bin/true
+          Run the following command to unload the jffs2 module:
+          # rmmod jffs2
+        scored: true
+      - id: 1.1.1.4.a
+        description: "Ensure mounting of hfs filesystems is disabled"
+        audit: "modprobe -n -v hfs"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/hfs.conf
+          and add the following line:
+          install hfs /bin/true
+          Run the following command to unload the hfs module:
+          # rmmod hfs
+        scored: true
+      - id: 1.1.1.4.b
+        description: "Ensure mounting of hfs filesystems is disabled"
+        audit: "lsmod | grep hfs"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/hfs.conf
+          and add the following line:
+          install hfs /bin/true
+          Run the following command to unload the hfs module:
+          # rmmod hfs
+        scored: true
+      - id: 1.1.1.5.a
+        description: "Ensure mounting of hfsplus filesystems is disabled"
+        audit: "modprobe -n -v hfsplus"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/hfsplus.conf
+          and add the following line:
+          install hfsplus /bin/true
+          Run the following command to unload the hfsplus module:
+          # rmmod hfsplus
+        scored: true
+      - id: 1.1.1.5.b
+        description: "Ensure mounting of hfsplus filesystems is disabled"
+        audit: "lsmod | grep hfsplus"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/hfsplus.conf
+          and add the following line:
+          install hfsplus /bin/true
+          Run the following command to unload the hfsplus module:
+          # rmmod hfsplus
+        scored: true
+      - id: 1.1.1.6.a
+        description: "Ensure mounting of squashfs filesystems is disabled"
+        sub_checks:
+          - check:
+              audit: "modprobe -n -v squashfs"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "install /bin/true"
+                    set: true
+              remediation: |
+                Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+                Example: vim /etc/modprobe.d/squashfs.conf
+                and add the following line:
+                install squashfs /bin/true
+                Run the following command to unload the squashfs module:
+                # rmmod squashfs
+        scored: true
+      - id: 1.1.1.6.b
+        description: "Ensure mounting of squashfs filesystems is disabled"
+        sub_checks:
+          - check:
+              audit: "lsmod | grep squashfs"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: ""
+                    set: true
+              remediation: |
+                Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+                Example: vim /etc/modprobe.d/squashfs.conf
+                and add the following line:
+                install squashfs /bin/true
+                Run the following command to unload the squashfs module:
+                # rmmod squashfs
+        scored: true
+      - id: 1.1.1.7.a
+        description: "Ensure mounting of udf filesystems is disabled"
+        audit: "modprobe -n -v udf"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/udf.conf
+          and add the following line: install udf /bin/true
+          Run the following command to unload the udf module:
+          # rmmod udf
+        scored: true
+      - id: 1.1.1.7.b
+        description: "Ensure mounting of udf filesystems is disabled"
+        audit: "lsmod | grep udf"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/udf.conf
+          and add the following line: install udf /bin/true
+          Run the following command to unload the udf module:
+          # rmmod udf
+        scored: true
+      - id: 1.1.1.8.a
+        description: "Ensure mounting of FAT filesystems is disabled"
+        sub_checks:
+          - check:
+              audit: "grep -i vfat /etc/fstab"
+              constraints:
+                platform:
+                  - rhel7
+              type: manual
+              remediation: |
+                Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+                Example: vim /etc/modprobe.d/vfat.conf
+                install vfat /bin/true
+                Run the following command to unload the vfat module:
+                # rmmod vfat
         scored: false
-    - id: 1.2.2
-      description: "Ensure GPG keys are configured"
-      sub_checks:
-      - check:
-          audit: "rpm -q gpg-pubkey --qf '%{name}-%{version}-%{release} --> %{summary}'"
-          constraints:
-            platform:
-            - rhel7
-          type: manual
-          remediation: |
+      - id: 1.1.1.8.b
+        description: "Ensure mounting of FAT filesystems is disabled"
+        sub_checks:
+          - check:
+              audit: "modprobe -n -v vfat"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "install /bin/true"
+                    set: true
+              remediation: |
+                Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+                Example: vim /etc/modprobe.d/vfat.conf
+                install vfat /bin/true
+                Run the following command to unload the vfat module:
+                # rmmod vfat
+        scored: false
+      - id: 1.1.1.8.c
+        description: "Ensure mounting of FAT filesystems is disabled"
+        sub_checks:
+          - check:
+              audit: "lsmod | grep vfat"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: ""
+                    set: true
+              remediation: |
+                Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+                Example: vim /etc/modprobe.d/vfat.conf
+                install vfat /bin/true
+                Run the following command to unload the vfat module:
+                # rmmod vfat
+        scored: false
+      - id: 1.1.2.a
+        description: "Ensure /tmp is configured"
+        audit: "mount | grep -E '\\s/tmp\\s'"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: false
+        remediation: |
+          Configure /etc/fstab as appropriate.
+          example:
+          tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0
+          OR
+          Run the following commands to enable systemd /tmp mounting:
+          systemctl unmask tmp.mount systemctl enable tmp.mount
+          Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount:
+          [Mount]
+          What=tmpfs
+          Where=/tmp
+          Type=tmpfs
+          Options=mode=1777,strictatime,noexec,nodev,nosuid
+        scored: true
+      - id: 1.1.2.b
+        description: "Ensure /tmp is configured"
+        audit: "grep -E '\\s/tmp\\s' /etc/fstab | grep -E -v '^\\s*#'"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: false
+        remediation: |
+          Configure /etc/fstab as appropriate.
+          example:
+          tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0
+          OR
+          Run the following commands to enable systemd /tmp mounting:
+          systemctl unmask tmp.mount systemctl enable tmp.mount
+          Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to configure the /tmp mount:
+          [Mount]
+          What=tmpfs
+          Where=/tmp
+          Type=tmpfs
+          Options=mode=1777,strictatime,noexec,nodev,nosuid
+        scored: true
+      - id: 1.1.3
+        description: "Ensure nodev option set on /tmp partition"
+        audit: "mount | grep -E '\\s/tmp\\s' | grep -v nodev"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition.
+          See the fstab(5) manual page for more information.
+          Run the following command to remount /tmp :
+          # mount -o remount,nodev /tmp
+          or
+          Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp mount options:
+          [Mount]
+          Options=mode=1777,strictatime,noexec,nodev,nosuid
+          un the following command to remount /tmp :
+          # mount -o remount,nodev /tmp
+        scored: true
+
+      - id: 1.1.4
+        description: "Ensure nosuid option set on /tmp partition"
+        audit: "mount | grep -E '\\s/tmp\\s' | grep -v nosuid"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp
+          partition. See the fstab(5) manual page for more information.
+          Run the following command to remount /tmp :
+          # mount -o remount,nosuid /tmp
+          or
+          Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp mount options:
+          [Mount]
+          Options=mode=1777,strictatime,noexec,nodev,nosuid
+          Run the following command to remount /tmp :
+          # mount -o remount,nosuid /tmp
+        scored: true
+
+      - id: 1.1.5
+        description: "Ensure noexec option set on /tmp partition"
+        audit: "mount | grep -E '\\s/tmp\\s' | grep -v noexec"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the `/etc/fstab` file and add `noexec` to the fourth field (mounting options) for the `/tmp` partition. See the `fstab(5)` manual page for more information.
+                      Run the following command to remount `/tmp` :
+
+          # mount -o remount,noexec /tmp
+
+        scored: true
+
+      - id: 1.1.6
+        description: "Ensure separate partition exists for /var"
+        audit: "mount | grep -E '\\s/var\\s'"
+        tests:
+          test_items:
+            - flag: "/dev/xvdg1 on /var type ext4 (rw,relatime,data=ordered)"
+              set: true
+        remediation: |
+          For new installations, during installation create a custom partition setup and specify a separate partition for `/var` .
+          For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
+        scored: true
+      - id: 1.1.7
+        description: "Ensure separate partition exists for /var/tmp"
+        audit: "mount | grep /var/tmp"
+        tests:
+          test_items:
+            - flag: " on /var/tmp type ext4 (rw,nosuid,nodev,noexec,relatime)"
+              set: true
+        remediation: |
+          For new installations, during installation create a custom partition setup and specify a separate partition for `/var/tmp` .
+          For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
+        scored: true
+      - id: 1.1.8
+        description: "Ensure nodev option set on /var/tmp partition"
+        audit: "mount | grep -E '\\s/var/tmp\\s' | grep -v nodev"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
+          /var/tmp partition. See the fstab(5) manual page for more information.
+          Run the following command to remount /var/tmp :
+          # mount -o remount,nodev /var/tmp
+
+        scored: true
+
+      - id: 1.1.9
+        description: "Ensure nosuid option set on /var/tmp partition"
+        audit: "mount | grep -E '\\s/var/tmp\\s' | grep -v nosuid"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
+          /var/tmp partition. See the fstab(5) manual page for more information.
+          Run the following command to remount /var/tmp :
+          # mount -o remount,nosuid /var/tmp
+
+        scored: true
+      - id: 1.1.10
+        description: "Ensure noexec option set on /var/tmp partition"
+        audit: "mount | grep -E '\\s/var/tmp\\s' | grep -v noexec"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
+          /var/tmp partition. See the fstab(5) manual page for more information.
+          Run the following command to remount /var/tmp :
+          # mount -o remount,noexec /var/tmp
+        scored: true
+      - id: 1.1.11
+        description: "Ensure separate partition exists for /var/log"
+        audit: "mount | grep /var/log"
+        tests:
+          test_items:
+            - flag: "/dev/xvdh1 on /var/log type ext4 (rw,relatime,data=ordered)"
+              set: true
+        remediation: |
+          For new installations, during installation create a custom partition setup and specify a separate partition for `/var/log` .
+          For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
+        scored: true
+      - id: 1.1.12
+        description: "Ensure separate partition exists for /var/log/audit"
+        audit: "mount | grep /var/log/audit"
+        tests:
+          test_items:
+            - flag: "/dev/xvdi1 on /var/log/audit type ext4 (rw,relatime,data=ordered)"
+              set: true
+        remediation: |
+          For new installations, during installation create a custom partition setup and specify a separate partition for `/var/log/audit` .
+          For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
+        scored: true
+      - id: 1.1.13
+        description: "Ensure separate partition exists for /home"
+        audit: "mount | grep /home"
+        tests:
+          test_items:
+            - flag: "/dev/xvdf1 on /home type ext4 (rw,nodev,relatime,data=ordered)"
+              set: true
+        remediation: |
+          For new installations, during installation create a custom partition setup and specify a separate partition for `/home` .
+          For systems that were previously installed, create a new partition and configure `/etc/fstab` as appropriate.
+        scored: true
+      - id: 1.1.14
+        description: "Ensure nodev option set on /home partition"
+        audit: "mount | grep -E '\\s/home\\s' | grep -v nodev"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the `/etc/fstab` file and add `nodev` to the fourth field (mounting options) for the `/home`
+          partition. See the `fstab(5)` manual page for more information.
+
+          # mount -o remount,nodev /home
+
+        scored: true
+
+      - id: 1.1.15
+        description: "Ensure nodev option set on /dev/shm partition"
+        audit: "mount | grep -E '\\s/dev/shm\\s' | grep -v nodev"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the `/etc/fstab` file and add `nodev` to the fourth field (mounting options) for the `/dev/shm` partition.
+          See the `fstab(5)` manual page for more information.
+          Run the following command to remount `/dev/shm` :
+
+          # mount -o remount,nodev /dev/shm
+
+        scored: true
+
+      - id: 1.1.16
+        description: "Ensure nosuid option set on /dev/shm partition"
+        audit: "mount | grep -E '\\s/dev/shm\\s' | grep -v nosuid"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the `/etc/fstab` file and add `nosuid` to the fourth field (mounting options) for the `/dev/shm` partition.
+          See the `fstab(5)` manual page for more information.
+          Run the following command to remount `/dev/shm` :
+
+          # mount -o remount,nosuid /dev/shm
+
+        scored: true
+
+      - id: 1.1.17
+        description: "Ensure noexec option set on /dev/shm partition"
+        audit: "mount | grep -E '\\s/dev/shm\\s' | grep -v noexec"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the `/etc/fstab` file and add `noexec` to the fourth field (mounting options) for the `/dev/shm` partition.
+          See the `fstab(5)` manual page for more information.
+          Run the following command to remount `/dev/shm` :
+
+          # mount -o remount,noexec /dev/shm
+
+        scored: true
+
+      - id: 1.1.18
+        description: "Ensure nodev option set on removable media partitions"
+        audit: "mount"
+        type: manual
+        remediation: |
+          Edit the `/etc/fstab` file and add `nodev` to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the `fstab(5)` manual page for more information.
+        scored: false
+
+      - id: 1.1.19
+        description: "Ensure nosuid option set on removable media partitions"
+        audit: "mount"
+        type: manual
+        remediation: |
+          Edit the `/etc/fstab` file and add `nosuid` to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the `fstab(5)` manual page for more information.
+        scored: false
+
+      - id: 1.1.20
+        description: "Ensure noexec option set on removable media partitions"
+        audit: "mount"
+        type: manual
+        remediation: |
+          Edit the `/etc/fstab` file and add `noexec` to the fourth field (mounting options) of all removable media partitions. Look for entries that have mount points that contain words such as floppy or cdrom. See the `fstab(5)` manual page for more information.
+        scored: false
+
+      - id: 1.1.21
+        description: "Ensure sticky bit is set on all world-writable directories"
+        audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null | head -n 100"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Run the following command to set the sticky bit on all world writable directories:
+          # df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null | xargs -I '{}' chmod a+t '{}'
+
+        scored: true
+
+      - id: 1.1.22
+        description: "Disable Automounting"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list autofs"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "autofs 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `autofs` :
+
+                # chkconfig autofs off
+
+
+                # systemctl disable autofs
+
+
+                # update-rc.d autofs disable
+          - check:
+              audit: "systemctl is-enabled autofs"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "disabled"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `autofs` :
+
+                # chkconfig autofs off
+
+
+                # systemctl disable autofs
+
+
+                # update-rc.d autofs disable
+          - check:
+              audit: "ls /etc/rc*.d | grep autofs"
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: ""
+                    compare:
+                      op: eq
+                      value: ""
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `autofs` :
+
+                # chkconfig autofs off
+
+
+                # systemctl disable autofs
+
+
+                # update-rc.d autofs disable
+        scored: true
+      - id: 1.1.23.a
+        description: "Disable USB Storage"
+        audit: "modprobe -n -v usb-storage"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/usb-storage.conf
+          and add the following line:
+          install usb-storage /bin/true
+          Run the following command to unload the usb-storage module:
+          # rmmod usb-storage
+        scored: true
+      - id: 1.1.23.b
+        description: "Disable USB Storage"
+        audit: "lsmod | grep usb-storage"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
+          Example: vim /etc/modprobe.d/usb-storage.conf
+          and add the following line:
+          install usb-storage /bin/true
+          Run the following command to unload the usb-storage module:
+          # rmmod usb-storage
+        scored: true
+  - id: 1.2
+    description: "Configure Software Updates"
+    checks:
+      - id: 1.2.1
+        description: "Ensure package manager repositories are configured"
+        sub_checks:
+          - check:
+              audit: "yum repo-list"
+              constraints:
+                platform:
+                  - rhel7
+              type: manual
+              remediation: |
+                Configure your package manager repositories according to site policy.
+          - check:
+              audit: "apt-cache policy"
+              constraints:
+                platform:
+                  - ubuntu16
+                  - ubuntu18
+              type: manual
+              remediation: |
+                Configure your package manager repositories according to site policy.
+          - check:
+              audit: "zypper repos"
+              constraints:
+                platform:
+                  - opensuse
+              type: manual
+              remediation: |
+                Configure your package manager repositories according to site policy.
+            scored: false
+      - id: 1.2.2
+        description: "Ensure GPG keys are configured"
+        sub_checks:
+          - check:
+              audit: "rpm -q gpg-pubkey --qf '%{name}-%{version}-%{release} --> %{summary}'"
+              constraints:
+                platform:
+                  - rhel7
+              type: manual
+              remediation: |
                 Update your package manager GPG keys in accordance with site policy.
-      - check:
-          audit: "apt-key list"
-          constraints:
-            platform:
-            - ubuntu16
-            - ubuntu18
-          type: manual
-          remediation: |
+          - check:
+              audit: "apt-key list"
+              constraints:
+                platform:
+                  - ubuntu16
+                  - ubuntu18
+              type: manual
+              remediation: |
                 Update your package manager GPG keys in accordance with site policy.
-      - check:
-          audit: "zypper repos"
-          constraints:
-            platform:
-            - opensuse
-          type: manual
-          remediation: |
+          - check:
+              audit: "zypper repos"
+              constraints:
+                platform:
+                  - opensuse
+              type: manual
+              remediation: |
                 Update your package manager GPG keys in accordance with site policy.
-      scored: false
-- id: 1.3
-  description: "Filesystem Integrity Checking"
-  checks:
-    - id: 1.3.1
-      description: "Ensure AIDE is installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q aide"   
-          constraints: 
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "package aide is not installed"
-              set: false                        
-          remediation: |
+        scored: false
+  - id: 1.3
+    description: "Filesystem Integrity Checking"
+    checks:
+      - id: 1.3.1
+        description: "Ensure AIDE is installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q aide"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "package aide is not installed"
+                    set: false
+              remediation: |
                 Install AIDE using the appropriate package manager or manual installation:
-                            
+
                 # yum install aide
-                
-                
+
+
                 # apt-get install aide
-                
-                
+
+
                 # zypper install aide
-                
+
                 Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options.
                             Initialize AIDE:
-                            
+
                 # aide --init
-      - check:
-          audit: "dpkg -s aide"   
-          constraints: 
-            platform:
-            - ubuntu16
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: true                        
-          remediation: |
+          - check:
+              audit: "dpkg -s aide"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
                 Install AIDE using the appropriate package manager or manual installation:
-                            
+
                 # yum install aide
-                
-                
+
+
                 # apt-get install aide
-                
-                
+
+
                 # zypper install aide
-                
+
                 Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options.
                             Initialize AIDE:
-                            
+
                 # aide --init
-      - check:
-          audit: "apt-cache show aide"   
-          constraints: 
-            platform:
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: true                        
-          remediation: |
+          - check:
+              audit: "apt-cache show aide"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
                 Install AIDE using the appropriate package manager or manual installation:
-                            
+
                 # yum install aide
-                
-                
+
+
                 # apt-get install aide
-                
-                
+
+
                 # zypper install aide
-                
+
                 Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options.
                             Initialize AIDE:
-                            
+
                 # aide --init
-      scored: true      
-    - id: 1.3.2.a
-      description: "Ensure filesystem integrity is regularly checked"
-      audit: "crontab -u root -l | grep aide"   
-      type: manual        
-      remediation: |
-            Run the following command:
-            
-            # crontab -u root -e
-            
-            Add the following line to the crontab:
-            
-            0 5 * * * /usr/sbin/aide --check
-            
-      scored: true                  
-            
-    - id: 1.3.2.b
-      description: "Ensure filesystem integrity is regularly checked"
-      audit: "grep -r aide /etc/cron.* /etc/crontab"   
-      type: manual                 
-      remediation: |
-            Run the following command:
-            
-            # crontab -u root -e
-            
-            Add the following line to the crontab:
-            
-            0 5 * * * /usr/sbin/aide --check
-            
-      scored: true                  
-            
-- id: 1.4
-  description: "Secure Boot Settings"
-  checks:                           
-    - id: 1.4.1
-      description: "Ensure permissions on bootloader config are configured"
-      sub_checks:
-      - check:
-          audit: "stat -c %a/Uid:%U/%uGid:%G/%g /boot/grub/menu.lst"   
-          constraints:
-            boot:
-            - grub
-          tests:
-            test_items:
-            - flag: "400/Uid:root/0Gid:root/0"
-              set: true                        
-          remediation: |
+        scored: true
+      - id: 1.3.2.a
+        description: "Ensure filesystem integrity is regularly checked"
+        audit: "crontab -u root -l | grep aide"
+        type: manual
+        remediation: |
+          Run the following command:
+
+          # crontab -u root -e
+
+          Add the following line to the crontab:
+
+          0 5 * * * /usr/sbin/aide --check
+
+        scored: true
+
+      - id: 1.3.2.b
+        description: "Ensure filesystem integrity is regularly checked"
+        audit: "grep -r aide /etc/cron.* /etc/crontab"
+        type: manual
+        remediation: |
+          Run the following command:
+
+          # crontab -u root -e
+
+          Add the following line to the crontab:
+
+          0 5 * * * /usr/sbin/aide --check
+
+        scored: true
+
+  - id: 1.4
+    description: "Secure Boot Settings"
+    checks:
+      - id: 1.4.1
+        description: "Ensure permissions on bootloader config are configured"
+        sub_checks:
+          - check:
+              audit: "stat -c %a/Uid:%U/%uGid:%G/%g /boot/grub/menu.lst"
+              constraints:
+                boot:
+                  - grub
+              tests:
+                test_items:
+                  - flag: "400/Uid:root/0Gid:root/0"
+                    set: true
+              remediation: |
                 Run the following commands to set permissions on your grub configuration:
-                            
+
                 # chown root:root /boot/grub/menu.lst
                 # chmod og-rwx /boot/grub/menu.lst
-      - check:
-          audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/default/grub"   
-          constraints:
-            boot:
-            - grub2
-          tests:
-            test_items:
-            - flag: "400/Uid:root/0Gid:root/0"
-              set: true                        
-          remediation: |
+          - check:
+              audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/default/grub"
+              constraints:
+                boot:
+                  - grub2
+              tests:
+                test_items:
+                  - flag: "400/Uid:root/0Gid:root/0"
+                    set: true
+              remediation: |
                 Run the following commands to set permissions on your grub configuration:
-                            
+
                 # chown root:root /etc/default/grub
-                # chmod og-rwx /etc/default/grub         
-      scored: true                  
-            
-    - id: 1.4.2
-      description: "Ensure bootloader password is set"
-      sub_checks:
-      - check:
-          audit: "grep \"^\\s*password\" /boot/grub/menu.lst"   
-          type: manual
-          constraints:
-            boot:
-            - grub
-          tests:
-            test_items:
-            - flag: "password --md5 "
-              set: true                        
-          remediation: |
-                For grub based systems create an encrypted password with grub-md5-crypt: 
-                # grub-crypt 
-                Password: <password> 
-                Retype Password: <password> 
+                # chmod og-rwx /etc/default/grub
+        scored: true
+
+      - id: 1.4.2
+        description: "Ensure bootloader password is set"
+        sub_checks:
+          - check:
+              audit: "grep \"^\\s*password\" /boot/grub/menu.lst"
+              type: manual
+              constraints:
+                boot:
+                  - grub
+              tests:
+                test_items:
+                  - flag: "password --md5 "
+                    set: true
+              remediation: |
+                For grub based systems create an encrypted password with grub-md5-crypt:
+                # grub-crypt
+                Password: <password>
+                Retype Password: <password>
                 <encrypted-password>
-                Copy and paste the <encrypted-password> into the global section of /boot/grub/menu.lst: 
+                Copy and paste the <encrypted-password> into the global section of /boot/grub/menu.lst:
                 password <encrypted-password>
-                For grub2 based systems Create an encrypted password with grub2-setpassword : 
-                # grub2-setpassword 
-                Enter password: <password> 
+                For grub2 based systems Create an encrypted password with grub2-setpassword :
+                # grub2-setpassword
+                Enter password: <password>
                 Confirm password: <password>
-                OR 
-                create an encrypted password with grub-mkpasswd-pbkdf2: 
-                # grub-mkpasswd-pbkdf2 
-                Enter password: <password> 
-                Reenter password: <password> 
+                OR
+                create an encrypted password with grub-mkpasswd-pbkdf2:
+                # grub-mkpasswd-pbkdf2
+                Enter password: <password>
+                Reenter password: <password>
                 Your PBKDF2 is <encrypted-password>
-                Add the following into /etc/grub.d/00_header or a custom /etc/grub.d configuration file: 
-                cat <<EOF 
-                set superusers="<username>" 
-                password_pbkdf2 <username> <encrypted-password> 
+                Add the following into /etc/grub.d/00_header or a custom /etc/grub.d configuration file:
+                cat <<EOF
+                set superusers="<username>"
+                password_pbkdf2 <username> <encrypted-password>
                 EOF
-                Run the following command to update the grub2 configuration: 
+                Run the following command to update the grub2 configuration:
                 # grub2-mkconfig -o /boot/grub2/grub.cfg
-                OR 
+                OR
                 # update-grub
-      - check:
-          audit: "grep \"^\\s*GRUB2_PASSWORD\" /boot/grub2/user.cfg"   
-          type: manual
-          constraints:
-            boot:
-            - grub2
-          tests:
-            test_items:
-            - flag: "password --md5 "
-              set: true                        
-          remediation: |
-                For grub based systems create an encrypted password with grub-md5-crypt: 
-                # grub-crypt 
-                Password: <password> 
-                Retype Password: <password> 
+          - check:
+              audit: "grep \"^\\s*GRUB2_PASSWORD\" /boot/grub2/user.cfg"
+              type: manual
+              constraints:
+                boot:
+                  - grub2
+              tests:
+                test_items:
+                  - flag: "password --md5 "
+                    set: true
+              remediation: |
+                For grub based systems create an encrypted password with grub-md5-crypt:
+                # grub-crypt
+                Password: <password>
+                Retype Password: <password>
                 <encrypted-password>
-                Copy and paste the <encrypted-password> into the global section of /boot/grub/menu.lst: 
+                Copy and paste the <encrypted-password> into the global section of /boot/grub/menu.lst:
                 password <encrypted-password>
-                For grub2 based systems Create an encrypted password with grub2-setpassword : 
-                # grub2-setpassword 
-                Enter password: <password> 
+                For grub2 based systems Create an encrypted password with grub2-setpassword :
+                # grub2-setpassword
+                Enter password: <password>
                 Confirm password: <password>
-                OR 
-                create an encrypted password with grub-mkpasswd-pbkdf2: 
-                # grub-mkpasswd-pbkdf2 
-                Enter password: <password> 
-                Reenter password: <password> 
+                OR
+                create an encrypted password with grub-mkpasswd-pbkdf2:
+                # grub-mkpasswd-pbkdf2
+                Enter password: <password>
+                Reenter password: <password>
                 Your PBKDF2 is <encrypted-password>
-                Add the following into /etc/grub.d/00_header or a custom /etc/grub.d configuration file: 
-                cat <<EOF 
-                set superusers="<username>" 
-                password_pbkdf2 <username> <encrypted-password> 
+                Add the following into /etc/grub.d/00_header or a custom /etc/grub.d configuration file:
+                cat <<EOF
+                set superusers="<username>"
+                password_pbkdf2 <username> <encrypted-password>
                 EOF
-                Run the following command to update the grub2 configuration: 
+                Run the following command to update the grub2 configuration:
                 # grub2-mkconfig -o /boot/grub2/grub.cfg
-                OR 
+                OR
                 # update-grub
-      scored: true                     
-    - id: 1.4.3
-      description: "Ensure authentication required for single user mode" 
-      type: manual            
-      remediation: |
-            Consult your documentation and configure single user mode to require a password for login as appropriate.
-      scored: true                  
-            
-    - id: 1.4.4
-      description: "Ensure interactive boot is not enabled"
-      sub_checks:
-      - check:
-          audit: "grep \"^PROMPT_FOR_CONFIRM=\" /etc/sysconfig/boot" 
-          constraints: 
-            boot:
-            - grub
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "PROMPT_FOR_CONFIRM=\"no\""
-              set: true                        
-          remediation: |
+        scored: true
+      - id: 1.4.3
+        description: "Ensure authentication required for single user mode"
+        type: manual
+        remediation: |
+          Consult your documentation and configure single user mode to require a password for login as appropriate.
+        scored: true
+
+      - id: 1.4.4
+        description: "Ensure interactive boot is not enabled"
+        sub_checks:
+          - check:
+              audit: 'grep "^PROMPT_FOR_CONFIRM=" /etc/sysconfig/boot'
+              constraints:
+                boot:
+                  - grub
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: 'PROMPT_FOR_CONFIRM="no"'
+                    set: true
+              remediation: |
                 If interactive boot is available disable it.
-      - check:
-          audit: "grep PROMPT /etc/sysconfig/init" 
-          constraints: 
-            boot:
-            - grub2
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "PROMPT"
+          - check:
+              audit: "grep PROMPT /etc/sysconfig/init"
+              constraints:
+                boot:
+                  - grub2
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "PROMPT"
+                    compare:
+                      op: eq
+                      value: "no"
+                    set: true
+              remediation: |
+                If interactive boot is available disable it.
+        scored: false
+
+  - id: 1.5
+    description: "Additional Process Hardening"
+    checks:
+      - id: 1.5.1.a
+        description: "Ensure core dumps are restricted"
+        audit: "grep \"hard\\s*core\" /etc/security/limits.conf /etc/security/limits.d/*"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "hard"
+              set: true
+            - flag: "core"
+              set: true
+        remediation: |
+          Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
+
+          * hard core 0
+
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          fs.suid_dumpable = 0
+
+          Run the following command to set the active kernel parameter:
+
+          # sysctl -w fs.suid_dumpable=0
+          If systemd-coredump is installed:
+          edit /etc/systemd/coredump.conf and add/modify the following lines:
+          Storage=none
+          ProcessSizeMax=0
+          Run the command:
+          systemctl daemon-reload
+
+        scored: true
+
+      - id: 1.5.1.b
+        description: "Ensure core dumps are restricted"
+        audit: "sysctl fs.suid_dumpable"
+        tests:
+          test_items:
+            - flag: "fs.suid_dumpable"
               compare:
                 op: eq
-                value: "no"
-              set: true                        
-          remediation: |
-                If interactive boot is available disable it.
-      scored: false                  
-                           
-            
-- id: 1.5
-  description: "Additional Process Hardening"
-  checks:
-    - id: 1.5.1.a
-      description: "Ensure core dumps are restricted"
-      audit: "grep \"hard\\s*core\" /etc/security/limits.conf /etc/security/limits.d/*"   
-      tests:
-        bin_op: and
-        test_items:                     
-        - flag: "hard"
-          set: true
-        - flag: "core"
-          set: true
-      remediation: |
-            Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
-            
-            * hard core 0
-            
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            fs.suid_dumpable = 0
-            
-            Run the following command to set the active kernel parameter:
-            
-            # sysctl -w fs.suid_dumpable=0
-            If systemd-coredump is installed: 
-            edit /etc/systemd/coredump.conf and add/modify the following lines: 
-            Storage=none 
-            ProcessSizeMax=0
-            Run the command: 
-            systemctl daemon-reload
-            
-      scored: true                  
-            
-    - id: 1.5.1.b
-      description: "Ensure core dumps are restricted"
-      audit: "sysctl fs.suid_dumpable"   
-      tests:
-        test_items:
-        - flag: "fs.suid_dumpable"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
-            
-            * hard core 0
-            
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            fs.suid_dumpable = 0
-            
-            Run the following command to set the active kernel parameter:
-            
-            # sysctl -w fs.suid_dumpable=0
-            If systemd-coredump is installed: 
-            edit /etc/systemd/coredump.conf and add/modify the following lines: 
-            Storage=none 
-            ProcessSizeMax=0
-            Run the command: 
-            systemctl daemon-reload
-      scored: true                  
-            
-    - id: 1.5.1.c
-      description: "Ensure core dumps are restricted"
-      audit: "grep \"fs\\.suid_dumpable\" /etc/sysctl.conf /etc/sysctl.d/* | head -n 1"   
-      tests:
-        test_items:
-        - flag: "fs.suid_dumpable"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
-            
-            * hard core 0
-            
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            fs.suid_dumpable = 0
-            
-            Run the following command to set the active kernel parameter:
-            
-            # sysctl -w fs.suid_dumpable=0
-            If systemd-coredump is installed: 
-            edit /etc/systemd/coredump.conf and add/modify the following lines: 
-            Storage=none 
-            ProcessSizeMax=0
-            Run the command: 
-            systemctl daemon-reload
-      scored: true                  
-    - id: 1.5.1.d
-      description: "Ensure core dumps are restricted"
-      audit: "systemctl is-enabled coredump.service"   
-      tests:
-        bin_op: or
-        test_items:
-        - flag: "enabled"
-          set: true      
-        - flag: "disabled"
-          set: true
-      remediation: |
-            Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
-            
-            * hard core 0
-            
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            fs.suid_dumpable = 0
-            
-            Run the following command to set the active kernel parameter:
-            
-            # sysctl -w fs.suid_dumpable=0
-            If systemd-coredump is installed: 
-            edit /etc/systemd/coredump.conf and add/modify the following lines: 
-            Storage=none 
-            ProcessSizeMax=0
-            Run the command: 
-            systemctl daemon-reload
-      scored: true      
-    - id: 1.5.2
-      description: "Ensure XD/NX support is enabled"
-      audit: "journalctl | grep 'protection: active'"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: has
-            value: "kernel: NX (Execute Disable) protection: active"
-          set: true                        
-      remediation: |
-            On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems:
-                        If necessary configure your bootloader to load the new kernel and reboot the system.
-                        You may need to enable NX or XD support in your bios.
-      scored: true                  
-            
-    - id: 1.5.3.a
-      description: "Ensure address space layout randomization (ASLR) is enabled"
-      audit: "sysctl kernel.randomize_va_space"   
-      tests:
-        test_items:
-        - flag: "kernel.randomize_va_space"
-          compare:
-            op: eq
-            value: "2"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            kernel.randomize_va_space = 2
-            
-            Run the following command to set the active kernel parameter:
-            
-            # sysctl -w kernel.randomize_va_space=2
-            
-      scored: true                  
-            
-    - id: 1.5.3.b
-      description: "Ensure address space layout randomization (ASLR) is enabled"
-      audit: "grep \"kernel\\.randomize_va_space\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "kernel.randomize_va_space"
-          compare:
-            op: eq
-            value: "2"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            kernel.randomize_va_space = 2
-            
-            Run the following command to set the active kernel parameter:
-            
-            # sysctl -w kernel.randomize_va_space=2
-            
-      scored: true                  
-            
-    - id: 1.5.4
-      description: "Ensure prelink is disabled"
-      sub_checks:
-      - check:
-          audit: "rpm -q prelink" 
-          constraints: 
-            platform:
-            - rhel7
-          tests:
-            test_items:            
-            - flag: "package prelink is not installed"          
-              set: true                      
-          remediation: |
+                value: "0"
+              set: true
+        remediation: |
+          Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
+
+          * hard core 0
+
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          fs.suid_dumpable = 0
+
+          Run the following command to set the active kernel parameter:
+
+          # sysctl -w fs.suid_dumpable=0
+          If systemd-coredump is installed:
+          edit /etc/systemd/coredump.conf and add/modify the following lines:
+          Storage=none
+          ProcessSizeMax=0
+          Run the command:
+          systemctl daemon-reload
+        scored: true
+
+      - id: 1.5.1.c
+        description: "Ensure core dumps are restricted"
+        audit: "grep \"fs\\.suid_dumpable\" /etc/sysctl.conf /etc/sysctl.d/* | head -n 1"
+        tests:
+          test_items:
+            - flag: "fs.suid_dumpable"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
+
+          * hard core 0
+
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          fs.suid_dumpable = 0
+
+          Run the following command to set the active kernel parameter:
+
+          # sysctl -w fs.suid_dumpable=0
+          If systemd-coredump is installed:
+          edit /etc/systemd/coredump.conf and add/modify the following lines:
+          Storage=none
+          ProcessSizeMax=0
+          Run the command:
+          systemctl daemon-reload
+        scored: true
+      - id: 1.5.1.d
+        description: "Ensure core dumps are restricted"
+        audit: "systemctl is-enabled coredump.service"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "enabled"
+              set: true
+            - flag: "disabled"
+              set: true
+        remediation: |
+          Add the following line to `/etc/security/limits.conf` or a `/etc/security/limits.d/*` file:
+
+          * hard core 0
+
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          fs.suid_dumpable = 0
+
+          Run the following command to set the active kernel parameter:
+
+          # sysctl -w fs.suid_dumpable=0
+          If systemd-coredump is installed:
+          edit /etc/systemd/coredump.conf and add/modify the following lines:
+          Storage=none
+          ProcessSizeMax=0
+          Run the command:
+          systemctl daemon-reload
+        scored: true
+      - id: 1.5.2
+        description: "Ensure XD/NX support is enabled"
+        audit: "journalctl | grep 'protection: active'"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: has
+                value: "kernel: NX (Execute Disable) protection: active"
+              set: true
+        remediation: |
+          On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit systems:
+                      If necessary configure your bootloader to load the new kernel and reboot the system.
+                      You may need to enable NX or XD support in your bios.
+        scored: true
+
+      - id: 1.5.3.a
+        description: "Ensure address space layout randomization (ASLR) is enabled"
+        audit: "sysctl kernel.randomize_va_space"
+        tests:
+          test_items:
+            - flag: "kernel.randomize_va_space"
+              compare:
+                op: eq
+                value: "2"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          kernel.randomize_va_space = 2
+
+          Run the following command to set the active kernel parameter:
+
+          # sysctl -w kernel.randomize_va_space=2
+
+        scored: true
+
+      - id: 1.5.3.b
+        description: "Ensure address space layout randomization (ASLR) is enabled"
+        audit: "grep \"kernel\\.randomize_va_space\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "kernel.randomize_va_space"
+              compare:
+                op: eq
+                value: "2"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          kernel.randomize_va_space = 2
+
+          Run the following command to set the active kernel parameter:
+
+          # sysctl -w kernel.randomize_va_space=2
+
+        scored: true
+
+      - id: 1.5.4
+        description: "Ensure prelink is disabled"
+        sub_checks:
+          - check:
+              audit: "rpm -q prelink"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "package prelink is not installed"
+                    set: true
+              remediation: |
                 Run the following command to restore binaries to normal:
-                            
+
                 # prelink -ua
-                
+
                 Uninstall `prelink` using the appropriate package manager or manual installation:
-                
+
                 # yum remove prelink
-                
-                
+
+
                 # apt-get remove prelink
-                
-                
+
+
                 # zypper remove prelink
-      - check:
-          audit: "dpkg -s prelink"
-          constraints: 
-            platform:
-            - ubuntu16
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: false          
-          remediation: |
-            Run the following command to restore binaries to normal:
-                        
-            # prelink -ua
-            
-            Uninstall `prelink` using the appropriate package manager or manual installation:
-            
-            yum remove prelink
-            
-            
-            apt-get remove prelink
-            
-            
-            zypper remove prelink 
-      - check:
-          audit: "apt-cache show prelink"
-          constraints: 
-            platform:
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: false          
-          remediation: |
-            Run the following command to restore binaries to normal:
-                        
-            # prelink -ua
-            
-            Uninstall `prelink` using the appropriate package manager or manual installation:
-            
-            yum remove prelink
-            
-            
-            apt-get remove prelink
-            
-            
-            zypper remove prelink
-      scored: true                           
-- id: 1.6
-  description: "Mandatory Access Control"
-  checks:
-- id: 1.6.1
-  description: "Ensure Mandatory Access Control Software is Installed"
-  checks:
-    - id: 1.6.1.1
-      description: "Ensure SELinux or AppArmor are installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q libselinux"
-          constraints:
-            platform:
-            - rhel7
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: false
-          remediation: |
-            Install SELinux or apparmor using the appropriate package manager or manual installation:
-            # yum install libselinux
-            # apt-get install libselinux1
-            # zypper install libselinux
-            The previous commands install SELinux, use the appropriate package if AppArmor is desired.
-      - check:
-          audit: "rpm -q apparmor"
-          constraints:
-            platform:
-            - rhel7
-            lsm:
-            - apparmor
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: false
-          remediation: |
-            Install SELinux or apparmor using the appropriate package manager or manual installation:
-            # yum install libselinux
-            # apt-get install libselinux1
-            # zypper install libselinux
-            The previous commands install SELinux, use the appropriate package if AppArmor is desired.
-      - check:
-          audit: "dpkg -s libselinux1"
-          constraints:
-            platform:
-            - ubuntu16
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: false
-          remediation: |
-            Install SELinux or apparmor using the appropriate package manager or manual installation:
-            # yum install libselinux
-            # apt-get install libselinux1
-            # zypper install libselinux
-            The previous commands install SELinux, use the appropriate package if AppArmor is desired.
-      - check:
-          audit: "dpkg -s apparmor"
-          constraints:
-            platform:
-            - ubuntu16
-            lsm:
-            - apparmor
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: true
-          remediation: |
-            Install SELinux or apparmor using the appropriate package manager or manual installation:
-            # yum install libselinux
-            # apt-get install libselinux1
-            # zypper install libselinux
-            The previous commands install SELinux, use the appropriate package if AppArmor is desired.
-      - check:
-          audit: "apt-cache show libselinux1"
-          constraints:
-            platform:
-            - ubuntu18
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: true
-          remediation: |
-            Install SELinux or apparmor using the appropriate package manager or manual installation:
-            # yum install libselinux
-            # apt-get install libselinux1
-            # zypper install libselinux
-            The previous commands install SELinux, use the appropriate package if AppArmor is desired.
-      - check:
-          audit: "apt-cache show apparmor"
-          constraints:
-            platform:
-            - ubuntu18
-            lsm:
-            - apparmor
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: true
-          remediation: |
-            Install SELinux or apparmor using the appropriate package manager or manual installation:
-            # yum install libselinux
-            # apt-get install libselinux1
-            # zypper install libselinux
-            The previous commands install SELinux, use the appropriate package if AppArmor is desired.
-    
-- id: 1.6.2
-  description: "Configure SELinux"
-  checks:
-    - id: 1.6.2.1
-      description: "Ensure SELinux is not disabled in bootloader configuration"
-      sub_checks:
-      - check:
-          audit: "grep \"^\\s*kernel\" /boot/grub/menu.lst"
-          constraints: 
-            lsm:
-            - selinux
-            boot:
-            - grub
-          tests:
-            bin_op: and
-            test_items:
-            - flag: "selinux"
-              compare:
-                op: eq
-                value: "0"
-              set: false            
-            - flag: "enforcing"
-              compare:
-                op: eq
-                value: "0"
-              set: false                                  
-          remediation: |
-              For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `selinux=0` and `enforcing=0` on all `kernel` lines.
-              For `grub2` based systems edit /etc/default/grub and remove all instances of `selinux=0` and `enforcing=0` from all CMDLINE\_LINUX parameters:
-              
-              GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-              GRUB_CMDLINE_LINUX=""
-              
-              Run the following command to update the `grub2` configuration:
-              
-              # update-grub
-      - check:
-          audit: "grep \"^\\s*linux\" /boot/grub2/grub.cfg"
-          constraints: 
-            lsm:
-            - selinux
-            boot:
-            - grub2
-          tests:
-            bin_op: and
-            test_items:
-            - flag: "selinux"
-              compare:
-                op: eq
-                value: "0"
-              set: false            
-            test_items:
-            - flag: "enforcing"
-              compare:
-                op: eq
-                value: "0"
-              set: false                                  
-          remediation: |
-              For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `selinux=0` and `enforcing=0` on all `kernel` lines.
-              For `grub2` based systems edit /etc/default/grub and remove all instances of `selinux=0` and `enforcing=0` from all CMDLINE\_LINUX parameters:
-              
-              GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-              GRUB_CMDLINE_LINUX=""
-              
-              Run the following command to update the `grub2` configuration:
-              
-              # update-grub
-              or 
-              # grub2-mkconfig -o /boot/grub2/guub.cfg
-      scored: true
-    - id: 1.6.2.2.a
-      description: "Ensure the SELinux state is enforcing"
-      sub_checks:
-      - check:
-          audit: "grep SELINUX=enforcing /etc/selinux/config"
-          constraints: 
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "SELINUX=enforcing"
-              set: true            
-          remediation: |
-            Edit the /etc/selinux/config file to set the SELINUX parameter: 
-            SELINUX=enforcing
-      scored: true
-    - id: 1.6.2.2.b
-      description: "Ensure the SELinux state is enforcing"
-      sub_checks:
-      - check:
-          audit: "sestatus"
-          constraints: 
-            lsm:
-            - selinux
-          tests:
-            bin_op: and
-            test_items:
-            - flag: "SELinux status:"
-              compare:
-                op: has
-                value: "enabled"
-              set: true
-            - flag: "Current mode:"
-              compare:
-                op: has
-                value: "enforcing"
-              set: true
-            - flag: "Mode from config file:"
-              compare: 
-                op: has
-                value: "enforcing"
-              set: true            
-          remediation: |
-            Edit the /etc/selinux/config file to set the SELINUX parameter: 
-            SELINUX=enforcing
-      scored: true
-    - id: 1.6.2.3.a
-      description: "Ensure SELinux policy is configured"
-      sub_checks:
-      - check:
-          audit: "grep SELINUXTYPE=targeted /etc/selinux/config"
-          constraints: 
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "SELINUXTYPE=targeted"
-              set: true          
-          remediation: |
-            Edit the `/etc/selinux/config` file to set the SELINUXTYPE parameter:
-              
-            SELINUXTYPE=targeted
-      scored: true
-    - id: 1.6.2.3.b
-      description: "Ensure SELinux policy is configured"
-      sub_checks:
-      - check:
-          audit: "sestatus"
-          constraints: 
-            lsm:
-            - selinux
-          tests:
-            bin_op: or
-            test_items:
-            - flag: "Policy from config file:"
-              compare:
-                op: has
-                value: "targeted"
-              set: true    
-            - flag: "Policy from config file:"
-              compare:
-                op: has
-                value: "mils"
-              set: true
-          remediation: |
-            Edit the `/etc/selinux/config` file to set the SELINUXTYPE parameter:
-              
-            SELINUXTYPE=targeted
-      scored: true  
+          - check:
+              audit: "dpkg -s prelink"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: false
+              remediation: |
+                Run the following command to restore binaries to normal:
 
-    
-    - id: 1.6.2.4
-      description: "Ensure SETroubleshoot is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q setroubleshoot"
-          constraints: 
-            platform:
-            - rhel7
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: true          
-          remediation: |
-            Uninstall s `etroubleshoot` using the appropriate package manager or manual installation:
-              
-              # yum remove setroubleshoot
-              
-              
-              # apt-get remove setroubleshoot
-              
-              
-              # zypper remove setroubleshoot
-      - check:
-          audit: "dpkg -s setroubleshoot"
-          constraints: 
-            platform:
-            - ubuntu16
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: true          
-          remediation: |
-            Uninstall s `etroubleshoot` using the appropriate package manager or manual installation:
-              
-              # yum remove setroubleshoot
-              
-              
-              # apt-get remove setroubleshoot
-              
-              
-              # zypper remove setroubleshoot
-      - check:
-          audit: "apt-cache show setroubleshoot"
-          constraints: 
-            platform:
-            - ubuntu18
-            lsm:
-            - selinux
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: false          
-          remediation: |
-            Uninstall s `etroubleshoot` using the appropriate package manager or manual installation:
-              
-              # yum remove setroubleshoot
-              
-              
-              # apt-get remove setroubleshoot
-              
-              
-              # zypper remove setroubleshoot
-      scored: true        
-    - id: 1.6.2.5
-      description: "Ensure the MCS Translation Service (mcstrans) is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q mcstrans"
-          constraints: 
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: true          
-          remediation: |
-            Uninstall `mcstrans` using the appropriate package manager or manual installation:
-              
-              yum remove mcstrans
-              
-              
-              apt-get remove mcstrans
-              
-              
-              zypper remove mcstrans
-      - check:
-          audit: "dpkg -s mcstrans"
-          constraints: 
-            platform:
-            - ubuntu16
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: false          
-          remediation: |
-            Uninstall `mcstrans` using the appropriate package manager or manual installation:
-              
-              yum remove mcstrans
-              
-              
-              apt-get remove mcstrans
-              
-              
-              zypper remove mcstrans 
-      - check:
-          audit: "apt-cache show mcstrans"
-          constraints: 
-            platform:
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: false          
-          remediation: |
-            Uninstall `mcstrans` using the appropriate package manager or manual installation:
-              
-              yum remove mcstrans
-              
-              
-              apt-get remove mcstrans
-              
-              
-              zypper remove mcstrans
-      scored: true
-    - id: 1.6.2.6
-      description: "Ensure no unconfined daemons exist"
-      audit: "ps -eZ | egrep \"initrc\" | grep -E -v -w \"tr|ps|egrep|bash|awk \" | tr ':' ' ' | awk '{ print $NF }'"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Investigate any unconfined daemons found during the audit action. They may need to have an existing security context assigned to them or a policy built for them.
-      scored: true
-- id: 1.6.3
-  description: "Configure AppArmor"
-  checks:
-    - id: 1.6.3.1
-      description: "Ensure AppArmor is not disabled in bootloader configuration"
-      sub_checks:
-      - check:
-          audit: "grep \"^\\s*kernel\" /boot/grub/menu.lst"
-          constraints:
-            lsm:
-            - apparmor
-            boot:
-            - grub
-          tests:
-            test_items:
-            - flag: "apparmor"
-              compare:
-                op: eq
-                value: "0"
-              set: false                        
-          remediation: |
-                For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `apparmor=0` on all `kernel` lines.
-                For `grub2` based systems edit /etc/default/grub and remove all instances of `apparmor=0` from all CMDLINE\_LINUX parameters:
-                
+                # prelink -ua
+
+                Uninstall `prelink` using the appropriate package manager or manual installation:
+
+                yum remove prelink
+
+
+                apt-get remove prelink
+
+
+                zypper remove prelink
+          - check:
+              audit: "apt-cache show prelink"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
+                Run the following command to restore binaries to normal:
+
+                # prelink -ua
+
+                Uninstall `prelink` using the appropriate package manager or manual installation:
+
+                yum remove prelink
+
+
+                apt-get remove prelink
+
+
+                zypper remove prelink
+        scored: true
+  - id: 1.6
+    description: "Mandatory Access Control"
+    checks:
+  - id: 1.6.1
+    description: "Ensure Mandatory Access Control Software is Installed"
+    checks:
+      - id: 1.6.1.1
+        description: "Ensure SELinux or AppArmor are installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q libselinux"
+              constraints:
+                platform:
+                  - rhel7
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: false
+              remediation: |
+                Install SELinux or apparmor using the appropriate package manager or manual installation:
+                # yum install libselinux
+                # apt-get install libselinux1
+                # zypper install libselinux
+                The previous commands install SELinux, use the appropriate package if AppArmor is desired.
+          - check:
+              audit: "rpm -q apparmor"
+              constraints:
+                platform:
+                  - rhel7
+                lsm:
+                  - apparmor
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: false
+              remediation: |
+                Install SELinux or apparmor using the appropriate package manager or manual installation:
+                # yum install libselinux
+                # apt-get install libselinux1
+                # zypper install libselinux
+                The previous commands install SELinux, use the appropriate package if AppArmor is desired.
+          - check:
+              audit: "dpkg -s libselinux1"
+              constraints:
+                platform:
+                  - ubuntu16
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: false
+              remediation: |
+                Install SELinux or apparmor using the appropriate package manager or manual installation:
+                # yum install libselinux
+                # apt-get install libselinux1
+                # zypper install libselinux
+                The previous commands install SELinux, use the appropriate package if AppArmor is desired.
+          - check:
+              audit: "dpkg -s apparmor"
+              constraints:
+                platform:
+                  - ubuntu16
+                lsm:
+                  - apparmor
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
+                Install SELinux or apparmor using the appropriate package manager or manual installation:
+                # yum install libselinux
+                # apt-get install libselinux1
+                # zypper install libselinux
+                The previous commands install SELinux, use the appropriate package if AppArmor is desired.
+          - check:
+              audit: "apt-cache show libselinux1"
+              constraints:
+                platform:
+                  - ubuntu18
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                Install SELinux or apparmor using the appropriate package manager or manual installation:
+                # yum install libselinux
+                # apt-get install libselinux1
+                # zypper install libselinux
+                The previous commands install SELinux, use the appropriate package if AppArmor is desired.
+          - check:
+              audit: "apt-cache show apparmor"
+              constraints:
+                platform:
+                  - ubuntu18
+                lsm:
+                  - apparmor
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                Install SELinux or apparmor using the appropriate package manager or manual installation:
+                # yum install libselinux
+                # apt-get install libselinux1
+                # zypper install libselinux
+                The previous commands install SELinux, use the appropriate package if AppArmor is desired.
+
+  - id: 1.6.2
+    description: "Configure SELinux"
+    checks:
+      - id: 1.6.2.1
+        description: "Ensure SELinux is not disabled in bootloader configuration"
+        sub_checks:
+          - check:
+              audit: "grep \"^\\s*kernel\" /boot/grub/menu.lst"
+              constraints:
+                lsm:
+                  - selinux
+                boot:
+                  - grub
+              tests:
+                bin_op: and
+                test_items:
+                  - flag: "selinux"
+                    compare:
+                      op: eq
+                      value: "0"
+                    set: false
+                  - flag: "enforcing"
+                    compare:
+                      op: eq
+                      value: "0"
+                    set: false
+              remediation: |
+                For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `selinux=0` and `enforcing=0` on all `kernel` lines.
+                For `grub2` based systems edit /etc/default/grub and remove all instances of `selinux=0` and `enforcing=0` from all CMDLINE\_LINUX parameters:
+
                 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
                 GRUB_CMDLINE_LINUX=""
-                
+
                 Run the following command to update the `grub2` configuration:
-                
+
                 # update-grub
-      - check:
-          audit: "grep LINUX /etc/default/grub"
-          constraints:
-            lsm:
-            - apparmor
-            boot:
-            - grub2
-          tests:
-            test_items:
-            - flag: "apparmor"
-              compare:
-                op: eq
-                value: "0"
-              set: false                        
-          remediation: |
-                For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `apparmor=0` on all `kernel` lines.
-                For `grub2` based systems edit /etc/default/grub and remove all instances of `apparmor=0` from all CMDLINE\_LINUX parameters:
-                
+          - check:
+              audit: "grep \"^\\s*linux\" /boot/grub2/grub.cfg"
+              constraints:
+                lsm:
+                  - selinux
+                boot:
+                  - grub2
+              tests:
+                bin_op: and
+                test_items:
+                  - flag: "selinux"
+                    compare:
+                      op: eq
+                      value: "0"
+                    set: false
+                  - flag: "enforcing"
+                    compare:
+                      op: eq
+                      value: "0"
+                    set: false
+              remediation: |
+                For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `selinux=0` and `enforcing=0` on all `kernel` lines.
+                For `grub2` based systems edit /etc/default/grub and remove all instances of `selinux=0` and `enforcing=0` from all CMDLINE\_LINUX parameters:
+
                 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
                 GRUB_CMDLINE_LINUX=""
-                
+
                 Run the following command to update the `grub2` configuration:
-                
+
                 # update-grub
-      scored: true  
-    - id: 1.6.3.2
-      description: "Ensure all AppArmor Profiles are enforcing"
-      sub_checks:
-      - check:
-          audit: "apparmor_status"
-          type: manual
-          constraints:
-            lsm:
-            - apparmor
-          tests:                      
-          remediation: |
+                or
+                # grub2-mkconfig -o /boot/grub2/guub.cfg
+        scored: true
+      - id: 1.6.2.2.a
+        description: "Ensure the SELinux state is enforcing"
+        sub_checks:
+          - check:
+              audit: "grep SELINUX=enforcing /etc/selinux/config"
+              constraints:
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "SELINUX=enforcing"
+                    set: true
+              remediation: |
+                Edit the /etc/selinux/config file to set the SELINUX parameter:
+                SELINUX=enforcing
+        scored: true
+      - id: 1.6.2.2.b
+        description: "Ensure the SELinux state is enforcing"
+        sub_checks:
+          - check:
+              audit: "sestatus"
+              constraints:
+                lsm:
+                  - selinux
+              tests:
+                bin_op: and
+                test_items:
+                  - flag: "SELinux status:"
+                    compare:
+                      op: has
+                      value: "enabled"
+                    set: true
+                  - flag: "Current mode:"
+                    compare:
+                      op: has
+                      value: "enforcing"
+                    set: true
+                  - flag: "Mode from config file:"
+                    compare:
+                      op: has
+                      value: "enforcing"
+                    set: true
+              remediation: |
+                Edit the /etc/selinux/config file to set the SELINUX parameter:
+                SELINUX=enforcing
+        scored: true
+      - id: 1.6.2.3.a
+        description: "Ensure SELinux policy is configured"
+        sub_checks:
+          - check:
+              audit: "grep SELINUXTYPE=targeted /etc/selinux/config"
+              constraints:
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "SELINUXTYPE=targeted"
+                    set: true
+              remediation: |
+                Edit the `/etc/selinux/config` file to set the SELINUXTYPE parameter:
+
+                SELINUXTYPE=targeted
+        scored: true
+      - id: 1.6.2.3.b
+        description: "Ensure SELinux policy is configured"
+        sub_checks:
+          - check:
+              audit: "sestatus"
+              constraints:
+                lsm:
+                  - selinux
+              tests:
+                bin_op: or
+                test_items:
+                  - flag: "Policy from config file:"
+                    compare:
+                      op: has
+                      value: "targeted"
+                    set: true
+                  - flag: "Policy from config file:"
+                    compare:
+                      op: has
+                      value: "mils"
+                    set: true
+              remediation: |
+                Edit the `/etc/selinux/config` file to set the SELINUXTYPE parameter:
+
+                SELINUXTYPE=targeted
+        scored: true
+
+      - id: 1.6.2.4
+        description: "Ensure SETroubleshoot is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q setroubleshoot"
+              constraints:
+                platform:
+                  - rhel7
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
+                Uninstall s `etroubleshoot` using the appropriate package manager or manual installation:
+
+                  # yum remove setroubleshoot
+
+
+                  # apt-get remove setroubleshoot
+
+
+                  # zypper remove setroubleshoot
+          - check:
+              audit: "dpkg -s setroubleshoot"
+              constraints:
+                platform:
+                  - ubuntu16
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
+                Uninstall s `etroubleshoot` using the appropriate package manager or manual installation:
+
+                  # yum remove setroubleshoot
+
+
+                  # apt-get remove setroubleshoot
+
+
+                  # zypper remove setroubleshoot
+          - check:
+              audit: "apt-cache show setroubleshoot"
+              constraints:
+                platform:
+                  - ubuntu18
+                lsm:
+                  - selinux
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
+                Uninstall s `etroubleshoot` using the appropriate package manager or manual installation:
+
+                  # yum remove setroubleshoot
+
+
+                  # apt-get remove setroubleshoot
+
+
+                  # zypper remove setroubleshoot
+        scored: true
+      - id: 1.6.2.5
+        description: "Ensure the MCS Translation Service (mcstrans) is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q mcstrans"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
+                Uninstall `mcstrans` using the appropriate package manager or manual installation:
+
+                  yum remove mcstrans
+
+
+                  apt-get remove mcstrans
+
+
+                  zypper remove mcstrans
+          - check:
+              audit: "dpkg -s mcstrans"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: false
+              remediation: |
+                Uninstall `mcstrans` using the appropriate package manager or manual installation:
+
+                  yum remove mcstrans
+
+
+                  apt-get remove mcstrans
+
+
+                  zypper remove mcstrans
+          - check:
+              audit: "apt-cache show mcstrans"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
+                Uninstall `mcstrans` using the appropriate package manager or manual installation:
+
+                  yum remove mcstrans
+
+
+                  apt-get remove mcstrans
+
+
+                  zypper remove mcstrans
+        scored: true
+      - id: 1.6.2.6
+        description: "Ensure no unconfined daemons exist"
+        audit: 'ps -eZ | egrep "initrc" | grep -E -v -w "tr|ps|egrep|bash|awk " | tr '':'' '' '' | awk ''{ print $NF }'''
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Investigate any unconfined daemons found during the audit action. They may need to have an existing security context assigned to them or a policy built for them.
+        scored: true
+  - id: 1.6.3
+    description: "Configure AppArmor"
+    checks:
+      - id: 1.6.3.1
+        description: "Ensure AppArmor is not disabled in bootloader configuration"
+        sub_checks:
+          - check:
+              audit: "grep \"^\\s*kernel\" /boot/grub/menu.lst"
+              constraints:
+                lsm:
+                  - apparmor
+                boot:
+                  - grub
+              tests:
+                test_items:
+                  - flag: "apparmor"
+                    compare:
+                      op: eq
+                      value: "0"
+                    set: false
+              remediation: |
+                For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `apparmor=0` on all `kernel` lines.
+                For `grub2` based systems edit /etc/default/grub and remove all instances of `apparmor=0` from all CMDLINE\_LINUX parameters:
+
+                GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+                GRUB_CMDLINE_LINUX=""
+
+                Run the following command to update the `grub2` configuration:
+
+                # update-grub
+          - check:
+              audit: "grep LINUX /etc/default/grub"
+              constraints:
+                lsm:
+                  - apparmor
+                boot:
+                  - grub2
+              tests:
+                test_items:
+                  - flag: "apparmor"
+                    compare:
+                      op: eq
+                      value: "0"
+                    set: false
+              remediation: |
+                For `grub` based systems edit `/boot/grub/menu.lst` and remove all instances of `apparmor=0` on all `kernel` lines.
+                For `grub2` based systems edit /etc/default/grub and remove all instances of `apparmor=0` from all CMDLINE\_LINUX parameters:
+
+                GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+                GRUB_CMDLINE_LINUX=""
+
+                Run the following command to update the `grub2` configuration:
+
+                # update-grub
+        scored: true
+      - id: 1.6.3.2
+        description: "Ensure all AppArmor Profiles are enforcing"
+        sub_checks:
+          - check:
+              audit: "apparmor_status"
+              type: manual
+              constraints:
+                lsm:
+                  - apparmor
+              tests:
+              remediation: |
                 Run the following command to set all profiles to enforce mode:
-            
+
                 # enforce /etc/apparmor.d/*
-            
+
                 Any unconfined processes may need to have a profile created or activated for them and then be restarted.
-      scored: true
-      
+        scored: true
 
-- id: 1.7
-  description: "Warning Banners"
-  checks:
-- id: 1.7.1
-  description: "Command Line Warning Banners"
-  checks:
-    - id: 1.7.1.1.a
-      description: "Ensure message of the day is configured properly"
-      audit: "cat /etc/motd"   
-      type: manual                
-      remediation: |
-        Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v.
-      scored: true                  
-            
-    - id: 1.7.1.1.b
-      description: "Ensure message of the day is configured properly"
-      audit: "grep -E -i \"(\\\\v|\\\\r|\\\\m|\\\\s|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/motd"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                           
-      remediation: |
-        Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v.
-      scored: true                  
-    - id: 1.7.1.2.a
-      description: "Ensure local login warning banner is configured properly"
-      audit: "cat /etc/issue"
-      type: manual
-      remediation: |
-        Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v :
-        # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue
-      scored: true                  
-    - id: 1.7.1.2.b
-      description: "Ensure local login warning banner is configured properly"
-      audit: "grep -E -i \"(\\\\v|\\\\r|\\\\m|\\\\s|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/issue"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                           
-      remediation: |
-        Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v :
-        # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue
-      scored: true                  
-    - id: 1.7.1.3.a
-      description: "Ensure remote login warning banner is configured properly"
-      audit: "cat /etc/issue.net" 
-      type: manual
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                           
-      remediation: |
-        Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v : 
-        # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue.net
-      scored: true                  
-            
-    - id: 1.7.1.3.b
-      description: "Ensure remote login warning banner is configured properly"
-      audit: "grep -E -i \"(\\\\v|\\\\r|\\\\m|\\\\s|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/issue.net"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                           
-      remediation: |
-        Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v :
-        # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue.net
-      scored: true                  
-    - id: 1.7.1.4
-      description: "Ensure permissions on /etc/motd are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/motd"   
-      tests:
-        test_items:
-        - flag: "644/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-        Run the following commands to set permissions on `/etc/motd` :
-        # chown root:root /etc/motd
-        # chmod 644 /etc/motd
-      scored: true                  
-           
-            
-    - id: 1.7.1.5
-      description: "Ensure permissions on /etc/issue are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/issue"   
-      tests:
-        test_items:
-        - flag: "644/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-        Run the following commands to set permissions on /etc/issue : 
-        # chown root:root /etc/issue 
-        # chmod 644 /etc/issue
-      scored: true                  
+  - id: 1.7
+    description: "Warning Banners"
+    checks:
+  - id: 1.7.1
+    description: "Command Line Warning Banners"
+    checks:
+      - id: 1.7.1.1.a
+        description: "Ensure message of the day is configured properly"
+        audit: "cat /etc/motd"
+        type: manual
+        remediation: |
+          Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v.
+        scored: true
 
-    - id: 1.7.1.6
-      description: "Ensure permissions on /etc/issue.net are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/issue.net"   
-      tests:
-        test_items:
-        - flag: "644/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-        Run the following commands to set permissions on /etc/issue.net : 
-        # chown root:root /etc/issue.net 
-        # chmod 644 /etc/issue.net
-      scored: true
-    - id: 1.7.2
-      description: "Ensure GDM login banner is configured"
-      audit: "grep -v ^#.* /etc/gdm3/greeter.dconf-defaults"
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "[org/gnome/login-screen]"
-          set: true
-        - flag: "banner-message-enable=true"
-          set: true
-        - flag: "banner-message-text"
-          set: true
-      remediation: |
-        Edit or create the file /etc/gdm3/greeter.dconf-defaults and add the following: 
-        [org/gnome/login-screen] 
-        banner-message-enable=true 
-        banner-message-text='Authorized uses only. All activity may be monitored and reported.'
-      scored: true
-
-- id: 1.8
-  description: "Ensure updates, patches, and additional security software are installed"
-  sub_checks:
-  - check:
-      audit: "yum check-update"
-      type: manual
-      constraints:
-        platform:
-        - rhel7
-      remediation: |
-        Use your package manager to update all packages on the system according to site policy.
-  - check:
-      audit: "apt-get -s upgrade"
-      type: manual
-      constraints:
-        platform:
-        - ubuntu16
-        - ubuntu18
-      remediation: |
-        Use your package manager to update all packages on the system according to site policy.
-  - check:
-      audit: "zypper list-updates"
-      type: manual
-      constraints:
-        platform:
-        - opensuse
-      remediation: |
-        Use your package manager to update all packages on the system according to site policy.
-  scored: false
-
-- id: 2
-  description: "Services"
-- id: 2.1
-  description: "inetd Services"
-  checks:
-    - id: 2.1.1.a
-      description: "Ensure chargen services are not enabled"
-      audit: "grep -R \"^chargen\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Comment out or remove any lines starting with `chargen` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `chargen` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-      
-    - id: 2.1.1.b
-      description: "Ensure chargen services are not enabled"
-      audit: "grep -R \"^chargen\" /etc/xinetd.conf /etc/xinetd.* "   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                        
-      remediation: |
-            Comment out or remove any lines starting with `chargen` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `chargen` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-            
-    - id: 2.1.2.a
-      description: "Ensure daytime services are not enabled"
-      audit: "grep -R \"^daytime\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `daytime` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `daytime` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-      
-    - id: 2.1.2.b
-      description: "Ensure daytime services are not enabled"
-      audit: "grep -R \"^daytime\" /etc/xinetd.conf /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `daytime` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `daytime` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-            
-    - id: 2.1.3.a
-      description: "Ensure discard services are not enabled"
-      audit: "grep -R \"^discard\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `discard` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `discard` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-      
-    - id: 2.1.3.b
-      description: "Ensure discard services are not enabled"
-      audit: "grep -R \"^discard\" /etc/xinetd.conf /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `discard` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `discard` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-            
-    - id: 2.1.4.a
-      description: "Ensure echo services are not enabled"
-      audit: "grep -R \"^echo\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `echo` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `echo` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-      
-    - id: 2.1.4.b
-      description: "Ensure echo services are not enabled"
-      audit: "grep -R \"^echo\" /etc/xinetd.conf /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `echo` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `echo` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-            
-    - id: 2.1.5.a
-      description: "Ensure time services are not enabled"
-      audit: "grep -R \"^time\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `time` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `time` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-      
-    - id: 2.1.5.b
-      description: "Ensure time services are not enabled"
-      audit: "grep -R \"^time\" /etc/xinetd.conf /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `time` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `time` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-            
-    - id: 2.1.6.a
-      description: "Ensure rsh server is not enabled"
-      audit: "grep -R \"^shell\" /etc/inetd.*; grep -R \"^login\" /etc/inetd.*; grep -R \"^exec\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `shell` , `login` , or `exec` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `rsh` , `rlogin` , and `rexec` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-      
-    - id: 2.1.6.b
-      description: "Ensure rsh server is not enabled"
-      audit: "grep -R \"^shell\" /etc/xinetd.*; grep -R \"^login\" /etc/xinetd.*; grep -R \"^exec\" /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `shell` , `login` , or `exec` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `rsh` , `rlogin` , and `rexec` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-            
-    - id: 2.1.7.a
-      description: "Ensure talk server is not enabled"
-      audit: "grep -R \"^talk\" /etc/inetd.*; grep -R \"^ntalk\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `talk` or `ntalk` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `talk` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-      
-    - id: 2.1.7.b
-      description: "Ensure talk server is not enabled"
-      audit: "grep -R \"^talk\" /etc/xinetd.*; grep -R \"^ntalk\" /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `talk` or `ntalk` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `talk` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-            
-    - id: 2.1.8.a
-      description: "Ensure telnet server is not enabled"
-      audit: "grep -R \"^telnet\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `telnet` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `telnet` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true 
-      
-    - id: 2.1.8.b
-      description: "Ensure telnet server is not enabled"
-      audit: "grep -R \"^telnet\" /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `telnet` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `telnet` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-          
-    - id: 2.1.9.a
-      description: "Ensure tftp server is not enabled"
-      audit: "grep -R \"^tftp\" /etc/inetd.*"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `tftp` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `tftp` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true                  
-    
-    - id: 2.1.9.b
-      description: "Ensure tftp server is not enabled"
-      audit: "grep -R \"^tftp\" /etc/xinetd.*"   
-      tests:
-        test_items:
-        - flag: "disable"
-          compare:
-            op: eq
-            value: "yes"
-          set: true                                  
-      remediation: |
-            Comment out or remove any lines starting with `tftp` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
-                        Set `disable = yes` on all `tftp` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
-      scored: true
-      
-    - id: 2.1.10
-      description: "Ensure xinetd service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list xinetd" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "xinetd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `xinetd` :
-                
-                # chkconfig xinetd off
-                
-                
-                # systemctl disable xinetd
-                
-                
-                # update-rc.d xinetd disable
-      - check:
-          audit: "systemctl is-enabled xinetd" 
-          constraints:          
-            platform:
-            - ubuntu18
-            #- rhel7
-            #- ubuntu16
-            #- ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `xinetd` :
-                
-                # chkconfig xinetd off
-                
-                
-                # systemctl disable xinetd
-                
-                
-                # update-rc.d xinetd disable
-      - check:
-          audit: "ls /etc/rc*.d | grep xinetd" 
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `xinetd` :
-                
-                # chkconfig xinetd off
-                
-                
-                # systemctl disable xinetd
-                
-                
-                # update-rc.d xinetd disable
-      scored: true
-    
-- id: 2.2
-  description: "Special Purpose Services"
-  checks:
-- id: 2.2.1
-  description: "Time Synchronization"
-  checks:
-    - id: 2.2.1.1.a
-      description: "Ensure time synchronization is in use"
-      sub_checks:
-      - check:
-          audit: "rpm -q ntp"
-          constraints: 
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "package ntp is not installed"
-              set: false    
-          remediation: |
-                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
-                            
-                # yum install ntp 
-                # dnf install ntp 
-                # apt-get install ntp 
-                # zypper install ntp 
-                # emerge ntp
-                
-                The previous commands install NTP, use the appropriate package if chrony is desired.
-                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
-      - check:
-          audit: "dpkg -s ntp"
-          constraints: 
-            platform:
-            - ubuntu16
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: true    
-          remediation: |
-                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
-                            
-                # yum install ntp 
-                # dnf install ntp 
-                # apt-get install ntp 
-                # zypper install ntp 
-                # emerge ntp
-                
-                The previous commands install NTP, use the appropriate package if chrony is desired.
-                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
-      - check:
-          audit: "apt-cache show ntp"
-          constraints: 
-            platform:
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: true    
-          remediation: |
-                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
-                            
-                # yum install ntp 
-                # dnf install ntp 
-                # apt-get install ntp 
-                # zypper install ntp 
-                # emerge ntp
-                
-                The previous commands install NTP, use the appropriate package if chrony is desired.
-                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
-
-      scored: false                  
-            
-    - id: 2.2.1.1.b
-      description: "Ensure time synchronization is in use"
-      sub_checks:
-      - check:
-          audit: "rpm -q chrony"   
-          constraints: 
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "package chrony is not installed"
-              set: false
-          remediation: |
-                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
-                            
-                # yum install ntp 
-                # dnf install ntp 
-                # apt-get install ntp 
-                # zypper install ntp 
-                # emerge ntp
-                
-                The previous commands install NTP, use the appropriate package if chrony is desired.
-                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
-      - check:
-          audit: "dpkg -s chrony"           
-          constraints: 
-            platform:
-            - ubuntu16
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: true    
-          remediation: |
-                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
-                          
-                # yum install ntp 
-                # dnf install ntp 
-                # apt-get install ntp 
-                # zypper install ntp 
-                # emerge ntp
-                
-                The previous commands install NTP, use the appropriate package if chrony is desired.
-                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
-      - check:
-          audit: "apt-cache show chrony"           
-          constraints: 
-            platform:
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: true    
-          remediation: |
-                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
-                            
-                # yum install ntp 
-                # dnf install ntp 
-                # apt-get install ntp 
-                # zypper install ntp 
-                # emerge ntp
-                
-                The previous commands install NTP, use the appropriate package if chrony is desired.
-                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
-
-      scored: false                  
-    - id: 2.2.1.2.a
-      description: "Ensure ntp is configured"
-      audit: "grep ^restrict /etc/ntp.conf"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "restrict -4 default kod nomodify notrap nopeer noquery"
-          set: true
-          flag: "restrict -6 default kod nomodify notrap nopeer noquery"
-          set: true
-      remediation: |
-            Add or edit restrict lines in `/etc/ntp.conf` to match the following:
-            
-            restrict -4 default kod nomodify notrap nopeer noquery
-            restrict -6 default kod nomodify notrap nopeer noquery
-            
-            Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
-            
-            server 
-            
-            Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
-            `/etc/sysconfig/ntpd` :
-            
-            OPTIONS="-u ntp:ntp"
-            
-            `/etc/sysconfig/ntp` :
-            
-            NTPD_OPTIONS="-u ntp:ntp"
-            
-            `/etc/init.d/ntp`:
-            
-            RUNASUSER=ntp
-            
-      scored: true                  
-            
-    - id: 2.2.1.2.b
-      description: "Ensure ntp is configured"
-      audit: "grep -E \"^(server|pool)\" /etc/ntp.conf"   
-      type: manual
-      tests:
-        test_items:
-        - flag: "server <remote-server>"
-          set: true                        
-      remediation: |
-            Add or edit restrict lines in `/etc/ntp.conf` to match the following:
-            
-            restrict -4 default kod nomodify notrap nopeer noquery
-            restrict -6 default kod nomodify notrap nopeer noquery
-            
-            Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
-            
-            server 
-            
-            Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
-            `/etc/sysconfig/ntpd` :
-            
-            OPTIONS="-u ntp:ntp"
-            
-            `/etc/sysconfig/ntp` :
-            
-            NTPD_OPTIONS="-u ntp:ntp"
-            
-            `/etc/init.d/ntp`:
-            
-            RUNASUSER=ntp
-            
-      scored: true                  
-            
-    - id: 2.2.1.2.c
-      description: "Ensure ntp is configured"
-      sub_checks:
-      - check:
-          audit: "grep ^OPTIONS /etc/sysconfig/ntpd"        
-          constraints:
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "OPTIONS=\"-u ntp:ntp\""
-              set: true                
-          remediation: |
-                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
-                
-                restrict -4 default kod nomodify notrap nopeer noquery
-                restrict -6 default kod nomodify notrap nopeer noquery
-                
-                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
-                
-                server 
-                
-                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
-                `/etc/sysconfig/ntpd` :
-                
-                OPTIONS="-u ntp:ntp"
-                
-                `/etc/sysconfig/ntp` :
-                
-                NTPD_OPTIONS="-u ntp:ntp"
-                
-                `/etc/init.d/ntp`:
-                
-                RUNASUSER=ntp
-      - check:
-          audit: "grep ^OPTIONS /etc/default/ntp"        
-          constraints:
-            platform:
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "OPTIONS=\"-u ntp:ntp\""
-              set: true                
-          remediation: |
-                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
-                
-                restrict -4 default kod nomodify notrap nopeer noquery
-                restrict -6 default kod nomodify notrap nopeer noquery
-                
-                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
-                
-                server 
-                
-                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
-                `/etc/default/ntp` :
-                
-                OPTIONS="-u ntp:ntp"
-                
-                `/etc/default/ntp` :
-                
-                NTPD_OPTIONS="-u ntp:ntp"
-                
-                `/etc/init.d/ntp`:
-                
-                RUNASUSER=ntp
-      scored: true                  
-            
-    - id: 2.2.1.2.d
-      description: "Ensure ntp is configured"
-      sub_checks:
-      - check:
-          audit: "grep ^NTPD_OPTIONS /etc/sysconfig/ntp"        
-          constraints:
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "NTPD_OPTIONS=\"-u ntp:ntp\""
-              set: true   
-          remediation: |
-                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
-                
-                restrict -4 default kod nomodify notrap nopeer noquery
-                restrict -6 default kod nomodify notrap nopeer noquery
-                
-                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
-                
-                server 
-                
-                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
-                `/etc/sysconfig/ntpd` :
-                
-                OPTIONS="-u ntp:ntp"
-                
-                `/etc/sysconfig/ntp` :
-                
-                NTPD_OPTIONS="-u ntp:ntp"
-                
-                `/etc/init.d/ntp`:
-                
-                RUNASUSER=ntp
-      - check:
-          audit: "grep ^NTPD_OPTIONS /etc/default/ntp"        
-          constraints:
-            platform:
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "NTPD_OPTIONS=\"-u ntp:ntp\""
-              set: true   
-          remediation: |
-                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
-                
-                restrict -4 default kod nomodify notrap nopeer noquery
-                restrict -6 default kod nomodify notrap nopeer noquery
-                
-                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
-                
-                server 
-                
-                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
-                `/etc/default/ntp` :
-                
-                OPTIONS="-u ntp:ntp"
-                
-                `/etc/default/ntp` :
-                
-                NTPD_OPTIONS="-u ntp:ntp"
-                
-                `/etc/init.d/ntp`:
-                
-                RUNASUSER=ntp
-      scored: true                  
-            
-    - id: 2.2.1.2.e
-      description: "Ensure ntp is configured"
-      audit: "grep RUNASUSER=ntp /etc/init.d/ntp"   
-      tests:
-        test_items:
-        - flag: "RUNASUSER"
-          compare:
-           op: eq
-           value: "ntp"
-          set: true                      
-      remediation: |
-            Add or edit restrict lines in `/etc/ntp.conf` to match the following:
-            
-            restrict -4 default kod nomodify notrap nopeer noquery
-            restrict -6 default kod nomodify notrap nopeer noquery
-            
-            Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
-            
-            server 
-            
-            Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
-            `/etc/sysconfig/ntpd` :
-            
-            OPTIONS="-u ntp:ntp"
-            
-            `/etc/sysconfig/ntp` :
-            
-            NTPD_OPTIONS="-u ntp:ntp"
-            
-            `/etc/init.d/ntp`:
-            
-            RUNASUSER=ntp
-            
-      scored: true                  
-            
-    - id: 2.2.1.3.a
-      description: "Ensure chrony is configured"
-      audit: "grep -E \"^(server|pool)\" /etc/chrony.conf"   
-      type: manual
-      tests:
-        test_items:
-        - flag: "server <remote-server>"
-          set: true                        
-      remediation: |
-            Add or edit server or pool lines to `/etc/chrony.conf` as appropriate:
-            
-            server 
-            
-            Configure `chrony` to run as the `chrony` user by configuring the appropriate startup script for your distribution. Startup scripts are typically stored in `/etc/init.d` or `/etc/systemd`.
-      scored: true                  
-            
-    - id: 2.2.1.3.b
-      description: "Ensure chrony is configured"
-      audit: "ps -ef | grep chronyd"   
-      type: manual                       
-      remediation: |
-            Add or edit server or pool lines to `/etc/chrony.conf` as appropriate:
-            
-            server 
-            
-            Configure `chrony` to run as the `chrony` user by configuring the appropriate startup script for your distribution. Startup scripts are typically stored in `/etc/init.d` or `/etc/systemd`.
-      scored: true   
-    - id: 2.2.1.4.a
-      description: "Ensure ntp is configured"
-      audit: "systemctl is-enabled systemd-timesyncd.service"   
-      tests:
-        test_items:
-        - flag: "enabled"
-          set: true
-      remediation: |
-            Run the following command to enable systemd-timesyncd 
-            systemctl enable systemd-timesyncd.service
-            edit the file /etc/systemd/timesyncd.conf and add/modify the following lines:
-            NTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy 
-            FallbackNTP=2.debian.pool.ntp.org 3.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy 
-            RootDistanceMax=1 #should be In Accordence With Local Policy
-            Run the following commands to start systemd-timesyncd.service 
-            # systemctl start systemd-timesyncd.service 
-            # timedatectl set-ntp true
-      scored: true                  
-            
-    - id: 2.2.1.4.b
-      description: "Ensure ntp is configured"
-      audit: "timedatectl status"   
-      type: manual                      
-      remediation: |
-            Run the following command to enable systemd-timesyncd 
-            systemctl enable systemd-timesyncd.service
-            edit the file /etc/systemd/timesyncd.conf and add/modify the following lines:
-            NTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy 
-            FallbackNTP=2.debian.pool.ntp.org 3.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy 
-            RootDistanceMax=1 #should be In Accordence With Local Policy
-            Run the following commands to start systemd-timesyncd.service 
-            # systemctl start systemd-timesyncd.service 
-            # timedatectl set-ntp true
-      scored: true                  
-            
-
-    - id: 2.2.2
-      description: "Ensure X Window System is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q xorg-x11*"
-          constraints:          
-            platform:
-            - rhel7
-          tests:          
-            test_items:
-            - flag: "is not installed"
-              set: true                                 
-          remediation: |
-                Remove the X Windows System packages using the appropriate package manager or manual installation:
-                            
-                yum remove xorg-x11*
-                
-                
-                apt-get remove xserver-xorg*
-                
-                
-                zypper remove xorg-x11*
-      - check:
-          audit: "dpkg -l xserver-xorg*"
-          constraints:          
-            platform:
-            - ubuntu16
-          tests:          
-            test_items:
-            - flag: "ii"
-              set: false                                 
-          remediation: |
-                Remove the X Windows System packages using the appropriate package manager or manual installation:
-                            
-                yum remove xorg-x11*
-                
-                
-                apt-get remove xserver-xorg*
-                
-                
-                zypper remove xorg-x11*
-      - check:
-          audit: "apt-cache policy xserver-xorg* | grep Installed -B1"
-          use_multiple_values: true
-          constraints:          
-            platform:
-            - ubuntu18
-          tests:
-            bin_op: or
-            test_items:
-            - flag: "Installed"
+      - id: 1.7.1.1.b
+        description: "Ensure message of the day is configured properly"
+        audit: "grep -E -i \"(\\\\v|\\\\r|\\\\m|\\\\s|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/motd"
+        tests:
+          test_items:
+            - flag: ""
               compare:
                 op: eq
-                value: "(none)"    
-              set: true   
-            - flag: "Installed"  
-              set: false     
-          remediation: |
-                Remove the X Windows System packages using the appropriate package manager or manual installation:
-                            
-                yum remove xorg-x11*
-                
-                
-                apt-get remove xserver-xorg*
-                
-                
-                zypper remove xorg-x11*
-      scored: true                  
-    - id: 2.2.3
-      description: "Ensure Avahi service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list avahi-daemon" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "avahi-daemon 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `avahi-daemon` :
-                
-                # chkconfig avahi-daemon off
-                
-                
-                # systemctl disable avahi-daemon
-                
-                
-                # update-rc.d avahi-daemon disable
-      - check:
-          audit: "systemctl is-enabled avahi-daemon" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `avahi-daemon` :
-                
-                # chkconfig avahi-daemon off
-                
-                
-                # systemctl disable avahi-daemon
-                
-                
-                # update-rc.d avahi-daemon disable
-      - check:
-          audit: "ls /etc/rc*.d | grep avahi-daemon" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `avahi-daemon` :
-                
-                # chkconfig avahi-daemon off
-                
-                
-                # systemctl disable avahi-daemon
-                
-                
-                # update-rc.d avahi-daemon disable
-      scored: true
-    - id: 2.2.4
-      description: "Ensure cups service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list cups" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "cups 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `cups` :
-                
-                # chkconfig cups off
-                
-                
-                # systemctl disable cups
-                
-                
-                # update-rc.d cups disable
-      - check:
-          audit: "systemctl is-enabled cups" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `cups` :
-                
-                # chkconfig cups off
-                
-                
-                # systemctl disable cups
-                
-                
-                # update-rc.d cups disable
-      - check:
-          audit: "ls /etc/rc*.d | grep cups" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `cups` :
-                
-                # chkconfig cups off
-                
-                
-                # systemctl disable cups
-                
-                
-                # update-rc.d cups disable
-      scored: true
-    - id: 2.2.5
-      description: "Ensure DHCP service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list dhcpd" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "dhcpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `dhcpd` :
-                
-                # chkconfig dhcpd off
-                
-                
-                # systemctl disable dhcpd
-                
-                
-                # update-rc.d dhcpd disable
-      - check:
-          audit: "systemctl is-enabled dhcpd" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `dhcpd` :
-                
-                # chkconfig dhcpd off
-                
-                
-                # systemctl disable dhcpd
-                
-                
-                # update-rc.d dhcpd disable
-      - check:
-          audit: "ls /etc/rc*.d | grep dhcpd" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `dhcpd` :
-                
-                # chkconfig dhcpd off
-                
-                
-                # systemctl disable dhcpd
-                
-                
-                # update-rc.d dhcpd disable
-      scored: true
-    - id: 2.2.6
-      description: "Ensure LDAP service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list slapd" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "slapd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `slapd` :
-                
-                # chkconfig slapd off
-                
-                
-                # systemctl disable slapd
-                
-                
-                # update-rc.d slapd disable
-      - check:
-          audit: "systemctl is-enabled slapd" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `slapd` :
-                
-                # chkconfig slapd off
-                
-                
-                # systemctl disable slapd
-                
-                
-                # update-rc.d slapd disable
-      - check:
-          audit: "ls /etc/rc*.d | grep slapd" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `slapd` :
-                
-                # chkconfig slapd off
-                
-                
-                # systemctl disable slapd
-                
-                
-                # update-rc.d slapd disable
-      scored: true
-
-    - id: 2.2.7.a
-      description: "Ensure NFS and RPC are not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list nfs" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "nfs 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `nfs` :
-                
-                # chkconfig nfs off
-                
-                
-                # systemctl disable nfs
-                
-                
-                # update-rc.d nfs disable
-      - check:
-          audit: "systemctl is-enabled nfs" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `nfs` :
-                
-                # chkconfig nfs off
-                
-                
-                # systemctl disable nfs
-                
-                
-                # update-rc.d nfs disable
-      - check:
-          audit: "ls /etc/rc*.d | grep nfs" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `nfs` :
-                
-                # chkconfig nfs off
-                
-                
-                # systemctl disable nfs
-                
-                
-                # update-rc.d nfs disable
-      scored: true
-    
-    - id: 2.2.7.b
-      description: "Ensure NFS and RPC are not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list rpcbind" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "rpcbind 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `rpcbind` :
-                
-                # chkconfig rpcbind off
-                
-                
-                # systemctl disable rpcbind
-                
-                
-                # update-rc.d rpcbind disable
-      - check:
-          audit: "systemctl is-enabled rpcbind" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `rpcbind` :
-                
-                # chkconfig rpcbind off
-                
-                
-                # systemctl disable rpcbind
-                
-                
-                # update-rc.d rpcbind disable
-      - check:
-          audit: "ls /etc/rc*.d | grep rpcbind" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "rpcbind"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `rpcbind` :
-                
-                # chkconfig rpcbind off
-                
-                
-                # systemctl disable rpcbind
-                
-                
-                # update-rc.d rpcbind disable
-      scored: true
-    
-    - id: 2.2.8
-      description: "Ensure DNS service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list named" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "named 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `named` :
-                
-                # chkconfig named off
-                
-                
-                # systemctl disable named
-                
-                
-                # update-rc.d named disable
-      - check:
-          audit: "systemctl is-enabled named" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `named` :
-                
-                # chkconfig named off
-                
-                
-                # systemctl disable named
-                
-                
-                # update-rc.d named disable
-      - check:
-          audit: "ls /etc/rc*.d | grep named"
-          type: manual           
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "named"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `named` :
-                
-                # chkconfig named off
-                
-                
-                # systemctl disable named
-                
-                
-                # update-rc.d named disable
-      scored: true    
-    - id: 2.2.9
-      description: "Ensure FTP service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list vsftpd" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "vsftpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `vsftpd` :
-                
-                # chkconfig vsftpd off
-                
-                
-                # systemctl disable vsftpd
-                
-                
-                # update-rc.d vsftpd disable
-      - check:
-          audit: "systemctl is-enabled vsftpd" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `vsftpd` :
-                
-                # chkconfig vsftpd off
-                
-                
-                # systemctl disable vsftpd
-                
-                
-                # update-rc.d vsftpd disable
-      - check:
-          audit: "ls /etc/rc*.d | grep vsftpd" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "vsftpd"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `vsftpd` :
-                
-                # chkconfig vsftpd off
-                
-                
-                # systemctl disable vsftpd
-                
-                
-                # update-rc.d vsftpd disable
-      scored: true
-    - id: 2.2.10
-      description: "Ensure HTTP service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list httpd" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "httpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `httpd` :
-                
-                # chkconfig httpd off
-                
-                
-                # systemctl disable httpd
-                
-                
-                # update-rc.d httpd disable
-      - check:
-          audit: "systemctl is-enabled httpd" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `httpd` :
-                
-                # chkconfig httpd off
-                
-                
-                # systemctl disable httpd
-                
-                
-                # update-rc.d httpd disable
-      - check:
-          audit: "ls /etc/rc*.d | grep httpd" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "httpd"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `httpd` :
-                
-                # chkconfig httpd off
-                
-                
-                # systemctl disable httpd
-                
-                
-                # update-rc.d httpd disable
-      scored: true
-    - id: 2.2.11
-      description: "Ensure IMAP and POP3 service are not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list dovecot" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "dovecot 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `dovecot` :
-                
-                # chkconfig dovecot off
-                
-                
-                # systemctl disable dovecot
-                
-                
-                # update-rc.d dovecot disable
-      - check:
-          audit: "systemctl is-enabled dovecot" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `dovecot` :
-                
-                # chkconfig dovecot off
-                
-                
-                # systemctl disable dovecot
-                
-                
-                # update-rc.d dovecot disable
-      - check:
-          audit: "ls /etc/rc*.d | grep dovecot" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "dovecot"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `dovecot` :
-                
-                # chkconfig dovecot off
-                
-                
-                # systemctl disable dovecot
-                
-                
-                # update-rc.d dovecot disable
-      scored: true
-    - id: 2.2.12
-      description: "Ensure Samba is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list smb" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "smb 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `smb` :
-                
-                # chkconfig smb off
-                
-                
-                # systemctl disable smb
-                
-                
-                # update-rc.d smb disable
-      - check:
-          audit: "systemctl is-enabled smb" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `smb` :
-                
-                # chkconfig smb off
-                
-                
-                # systemctl disable smb
-                
-                
-                # update-rc.d smb disable
-      - check:
-          audit: "ls /etc/rc*.d | grep smb" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "smb"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `smb` :
-                
-                # chkconfig smb off
-                
-                
-                # systemctl disable smb
-                
-                
-                # update-rc.d smb disable
-      scored: true
-    - id: 2.2.13
-      description: "Ensure HTTP Proxy Server is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list squid" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "squid 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `squid` :
-                
-                # chkconfig squid off
-                
-                
-                # systemctl disable squid
-                
-                
-                # update-rc.d squid disable
-      - check:
-          audit: "systemctl is-enabled squid" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `squid` :
-                
-                # chkconfig squid off
-                
-                
-                # systemctl disable squid
-                
-                
-                # update-rc.d squid disable
-      - check:
-          audit: "ls /etc/rc*.d | grep squid" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "squid"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `squid` :
-                
-                # chkconfig squid off
-                
-                
-                # systemctl disable squid
-                
-                
-                # update-rc.d squid disable
-      scored: true
-    - id: 2.2.14
-      description: "Ensure SNMP Server is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list snmpd" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "snmpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `snmpd` :
-                
-                # chkconfig snmpd off
-                
-                
-                # systemctl disable snmpd
-                
-                
-                # update-rc.d snmpd disable
-      - check:
-          audit: "systemctl is-enabled snmpd" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `snmpd` :
-                
-                # chkconfig snmpd off
-                
-                
-                # systemctl disable snmpd
-                
-                
-                # update-rc.d snmpd disable
-      - check:
-          audit: "ls /etc/rc*.d | grep snmpd" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "snmpd"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `snmpd` :
-                
-                # chkconfig snmpd off
-                
-                
-                # systemctl disable snmpd
-                
-                
-                # update-rc.d snmpd disable
-      scored: true
-    - id: 2.2.15
-      description: "Ensure mail transfer agent is configured for local-only mode"
-      audit: | 
-            ss -lntu | grep -E ':25\\s' | grep -E -v '\\s(127.0.0.1|::1):25\\s'  
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true   
-      remediation: |
-            Edit `/etc/postfix/main.cf` and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below:
-            
-            inet_interfaces = loopback-only
-            
-            Restart postfix with one of the following commands:
-            
-            # service postfix restart
-            # systemctl restart postfix
-            
-      scored: true                  
-            
-    - id: 2.2.16
-      description: "Ensure rsync service is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list rsyncd" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "rsyncd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `rsyncd` :
-                
-                # chkconfig rsyncd off
-                
-                
-                # systemctl disable rsyncd
-                
-                
-                # update-rc.d rsyncd disable
-      - check:
-          audit: "systemctl is-enabled rsyncd" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `rsyncd` :
-                
-                # chkconfig rsyncd off
-                
-                
-                # systemctl disable rsyncd
-                
-                
-                # update-rc.d rsyncd disable
-      - check:
-          audit: "ls /etc/rc*.d | grep rsyncd" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "rsyncd"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `rsyncd` :
-                
-                # chkconfig rsyncd off
-                
-                
-                # systemctl disable rsyncd
-                
-                
-                # update-rc.d rsyncd disable
-      scored: true
-    - id: 2.2.17
-      description: "Ensure NIS Server is not enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list ypserv" 
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "ypserv 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
-              set: true                        
-          remediation: |
-                Run one of the following commands to disable `ypserv` :
-                
-                # chkconfig ypserv off
-                
-                
-                # systemctl disable ypserv
-                
-                
-                # update-rc.d ypserv disable
-      - check:
-          audit: "systemctl is-enabled ypserv" 
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `ypserv` :
-                
-                # chkconfig ypserv off
-                
-                
-                # systemctl disable ypserv
-                
-                
-                # update-rc.d ypserv disable
-      - check:
-          audit: "ls /etc/rc*.d | grep ypserv" 
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: "ypserv"
-              set: false                        
-          remediation: |
-                Run one of the following commands to disable `ypserv` :
-                
-                # chkconfig ypserv off
-                
-                
-                # systemctl disable ypserv
-                
-                
-                # update-rc.d ypserv disable
-      scored: true
-           
-- id: 2.3
-  description: "Service Clients"
-  checks:
-    - id: 2.3.1
-      description: "Ensure NIS Client is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q ypbind"   
-          constraints:          
-            platform:
-            - rhel7
-          
-          tests:
-            test_items:        
-            - flag: "is not installed"  
+                value: ""
               set: true
+        remediation: |
+          Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v.
+        scored: true
+      - id: 1.7.1.2.a
+        description: "Ensure local login warning banner is configured properly"
+        audit: "cat /etc/issue"
+        type: manual
+        remediation: |
+          Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v :
+          # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue
+        scored: true
+      - id: 1.7.1.2.b
+        description: "Ensure local login warning banner is configured properly"
+        audit: "grep -E -i \"(\\\\v|\\\\r|\\\\m|\\\\s|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/issue"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v :
+          # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue
+        scored: true
+      - id: 1.7.1.3.a
+        description: "Ensure remote login warning banner is configured properly"
+        audit: "cat /etc/issue.net"
+        type: manual
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v :
+          # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue.net
+        scored: true
+
+      - id: 1.7.1.3.b
+        description: "Ensure remote login warning banner is configured properly"
+        audit: "grep -E -i \"(\\\\v|\\\\r|\\\\m|\\\\s|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/issue.net"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \m , \r , \s , or \v :
+          # echo "Authorized uses only. All activity may be monitored and reported." > /etc/issue.net
+        scored: true
+      - id: 1.7.1.4
+        description: "Ensure permissions on /etc/motd are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/motd"
+        tests:
+          test_items:
+            - flag: "644/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set permissions on `/etc/motd` :
+          # chown root:root /etc/motd
+          # chmod 644 /etc/motd
+        scored: true
+
+      - id: 1.7.1.5
+        description: "Ensure permissions on /etc/issue are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/issue"
+        tests:
+          test_items:
+            - flag: "644/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set permissions on /etc/issue :
+          # chown root:root /etc/issue
+          # chmod 644 /etc/issue
+        scored: true
+
+      - id: 1.7.1.6
+        description: "Ensure permissions on /etc/issue.net are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/issue.net"
+        tests:
+          test_items:
+            - flag: "644/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set permissions on /etc/issue.net :
+          # chown root:root /etc/issue.net
+          # chmod 644 /etc/issue.net
+        scored: true
+      - id: 1.7.2
+        description: "Ensure GDM login banner is configured"
+        audit: "grep -v ^#.* /etc/gdm3/greeter.dconf-defaults"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "[org/gnome/login-screen]"
+              set: true
+            - flag: "banner-message-enable=true"
+              set: true
+            - flag: "banner-message-text"
+              set: true
+        remediation: |
+          Edit or create the file /etc/gdm3/greeter.dconf-defaults and add the following:
+          [org/gnome/login-screen]
+          banner-message-enable=true
+          banner-message-text='Authorized uses only. All activity may be monitored and reported.'
+        scored: true
+
+  - id: 1.8
+    description: "Ensure updates, patches, and additional security software are installed"
+    sub_checks:
+      - check:
+          audit: "yum check-update"
+          type: manual
+          constraints:
+            platform:
+              - rhel7
           remediation: |
+            Use your package manager to update all packages on the system according to site policy.
+      - check:
+          audit: "apt-get -s upgrade"
+          type: manual
+          constraints:
+            platform:
+              - ubuntu16
+              - ubuntu18
+          remediation: |
+            Use your package manager to update all packages on the system according to site policy.
+      - check:
+          audit: "zypper list-updates"
+          type: manual
+          constraints:
+            platform:
+              - opensuse
+          remediation: |
+            Use your package manager to update all packages on the system according to site policy.
+    scored: false
+
+  - id: 2
+    description: "Services"
+  - id: 2.1
+    description: "inetd Services"
+    checks:
+      - id: 2.1.1.a
+        description: "Ensure chargen services are not enabled"
+        audit: 'grep -R "^chargen" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `chargen` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `chargen` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.1.b
+        description: "Ensure chargen services are not enabled"
+        audit: 'grep -R "^chargen" /etc/xinetd.conf /etc/xinetd.* '
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `chargen` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `chargen` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.2.a
+        description: "Ensure daytime services are not enabled"
+        audit: 'grep -R "^daytime" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `daytime` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `daytime` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.2.b
+        description: "Ensure daytime services are not enabled"
+        audit: 'grep -R "^daytime" /etc/xinetd.conf /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `daytime` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `daytime` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.3.a
+        description: "Ensure discard services are not enabled"
+        audit: 'grep -R "^discard" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `discard` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `discard` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.3.b
+        description: "Ensure discard services are not enabled"
+        audit: 'grep -R "^discard" /etc/xinetd.conf /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `discard` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `discard` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.4.a
+        description: "Ensure echo services are not enabled"
+        audit: 'grep -R "^echo" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `echo` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `echo` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.4.b
+        description: "Ensure echo services are not enabled"
+        audit: 'grep -R "^echo" /etc/xinetd.conf /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `echo` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `echo` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.5.a
+        description: "Ensure time services are not enabled"
+        audit: 'grep -R "^time" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `time` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `time` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.5.b
+        description: "Ensure time services are not enabled"
+        audit: 'grep -R "^time" /etc/xinetd.conf /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `time` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `time` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.6.a
+        description: "Ensure rsh server is not enabled"
+        audit: 'grep -R "^shell" /etc/inetd.*; grep -R "^login" /etc/inetd.*; grep -R "^exec" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `shell` , `login` , or `exec` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `rsh` , `rlogin` , and `rexec` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.6.b
+        description: "Ensure rsh server is not enabled"
+        audit: 'grep -R "^shell" /etc/xinetd.*; grep -R "^login" /etc/xinetd.*; grep -R "^exec" /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `shell` , `login` , or `exec` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `rsh` , `rlogin` , and `rexec` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.7.a
+        description: "Ensure talk server is not enabled"
+        audit: 'grep -R "^talk" /etc/inetd.*; grep -R "^ntalk" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `talk` or `ntalk` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `talk` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.7.b
+        description: "Ensure talk server is not enabled"
+        audit: 'grep -R "^talk" /etc/xinetd.*; grep -R "^ntalk" /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `talk` or `ntalk` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `talk` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.8.a
+        description: "Ensure telnet server is not enabled"
+        audit: 'grep -R "^telnet" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `telnet` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `telnet` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.8.b
+        description: "Ensure telnet server is not enabled"
+        audit: 'grep -R "^telnet" /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `telnet` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `telnet` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.9.a
+        description: "Ensure tftp server is not enabled"
+        audit: 'grep -R "^tftp" /etc/inetd.*'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `tftp` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `tftp` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.9.b
+        description: "Ensure tftp server is not enabled"
+        audit: 'grep -R "^tftp" /etc/xinetd.*'
+        tests:
+          test_items:
+            - flag: "disable"
+              compare:
+                op: eq
+                value: "yes"
+              set: true
+        remediation: |
+          Comment out or remove any lines starting with `tftp` from `/etc/inetd.conf` and `/etc/inetd.d/*` .
+                      Set `disable = yes` on all `tftp` services in `/etc/xinetd.conf` and `/etc/xinetd.d/*` .
+        scored: true
+
+      - id: 2.1.10
+        description: "Ensure xinetd service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list xinetd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "xinetd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `xinetd` :
+
+                # chkconfig xinetd off
+
+
+                # systemctl disable xinetd
+
+
+                # update-rc.d xinetd disable
+          - check:
+              audit: "systemctl is-enabled xinetd"
+              constraints:
+                platform:
+                  - ubuntu18
+                #- rhel7
+                #- ubuntu16
+                #- ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `xinetd` :
+
+                # chkconfig xinetd off
+
+
+                # systemctl disable xinetd
+
+
+                # update-rc.d xinetd disable
+          - check:
+              audit: "ls /etc/rc*.d | grep xinetd"
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `xinetd` :
+
+                # chkconfig xinetd off
+
+
+                # systemctl disable xinetd
+
+
+                # update-rc.d xinetd disable
+        scored: true
+
+  - id: 2.2
+    description: "Special Purpose Services"
+    checks:
+  - id: 2.2.1
+    description: "Time Synchronization"
+    checks:
+      - id: 2.2.1.1.a
+        description: "Ensure time synchronization is in use"
+        sub_checks:
+          - check:
+              audit: "rpm -q ntp"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "package ntp is not installed"
+                    set: false
+              remediation: |
+                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
+
+                # yum install ntp
+                # dnf install ntp
+                # apt-get install ntp
+                # zypper install ntp
+                # emerge ntp
+
+                The previous commands install NTP, use the appropriate package if chrony is desired.
+                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
+          - check:
+              audit: "dpkg -s ntp"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
+                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
+
+                # yum install ntp
+                # dnf install ntp
+                # apt-get install ntp
+                # zypper install ntp
+                # emerge ntp
+
+                The previous commands install NTP, use the appropriate package if chrony is desired.
+                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
+          - check:
+              audit: "apt-cache show ntp"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
+
+                # yum install ntp
+                # dnf install ntp
+                # apt-get install ntp
+                # zypper install ntp
+                # emerge ntp
+
+                The previous commands install NTP, use the appropriate package if chrony is desired.
+                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
+
+        scored: false
+
+      - id: 2.2.1.1.b
+        description: "Ensure time synchronization is in use"
+        sub_checks:
+          - check:
+              audit: "rpm -q chrony"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "package chrony is not installed"
+                    set: false
+              remediation: |
+                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
+
+                # yum install ntp
+                # dnf install ntp
+                # apt-get install ntp
+                # zypper install ntp
+                # emerge ntp
+
+                The previous commands install NTP, use the appropriate package if chrony is desired.
+                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
+          - check:
+              audit: "dpkg -s chrony"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
+                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
+
+                # yum install ntp
+                # dnf install ntp
+                # apt-get install ntp
+                # zypper install ntp
+                # emerge ntp
+
+                The previous commands install NTP, use the appropriate package if chrony is desired.
+                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
+          - check:
+              audit: "apt-cache show chrony"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                On physical systems or virtual systems where host based time synchronization is not available install NTP or chrony using the appropriate package manager or manual installation:
+
+                # yum install ntp
+                # dnf install ntp
+                # apt-get install ntp
+                # zypper install ntp
+                # emerge ntp
+
+                The previous commands install NTP, use the appropriate package if chrony is desired.
+                            On virtual systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization.
+
+        scored: false
+      - id: 2.2.1.2.a
+        description: "Ensure ntp is configured"
+        audit: "grep ^restrict /etc/ntp.conf"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "restrict -4 default kod nomodify notrap nopeer noquery"
+              set: true
+            - flag: "restrict -6 default kod nomodify notrap nopeer noquery"
+              set: true
+        remediation: |
+          Add or edit restrict lines in `/etc/ntp.conf` to match the following:
+
+          restrict -4 default kod nomodify notrap nopeer noquery
+          restrict -6 default kod nomodify notrap nopeer noquery
+
+          Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
+
+          server
+
+          Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
+          `/etc/sysconfig/ntpd` :
+
+          OPTIONS="-u ntp:ntp"
+
+          `/etc/sysconfig/ntp` :
+
+          NTPD_OPTIONS="-u ntp:ntp"
+
+          `/etc/init.d/ntp`:
+
+          RUNASUSER=ntp
+
+        scored: true
+
+      - id: 2.2.1.2.b
+        description: "Ensure ntp is configured"
+        audit: 'grep -E "^(server|pool)" /etc/ntp.conf'
+        type: manual
+        tests:
+          test_items:
+            - flag: "server <remote-server>"
+              set: true
+        remediation: |
+          Add or edit restrict lines in `/etc/ntp.conf` to match the following:
+
+          restrict -4 default kod nomodify notrap nopeer noquery
+          restrict -6 default kod nomodify notrap nopeer noquery
+
+          Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
+
+          server
+
+          Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
+          `/etc/sysconfig/ntpd` :
+
+          OPTIONS="-u ntp:ntp"
+
+          `/etc/sysconfig/ntp` :
+
+          NTPD_OPTIONS="-u ntp:ntp"
+
+          `/etc/init.d/ntp`:
+
+          RUNASUSER=ntp
+
+        scored: true
+
+      - id: 2.2.1.2.c
+        description: "Ensure ntp is configured"
+        sub_checks:
+          - check:
+              audit: "grep ^OPTIONS /etc/sysconfig/ntpd"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: 'OPTIONS="-u ntp:ntp"'
+                    set: true
+              remediation: |
+                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
+
+                restrict -4 default kod nomodify notrap nopeer noquery
+                restrict -6 default kod nomodify notrap nopeer noquery
+
+                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
+
+                server
+
+                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
+                `/etc/sysconfig/ntpd` :
+
+                OPTIONS="-u ntp:ntp"
+
+                `/etc/sysconfig/ntp` :
+
+                NTPD_OPTIONS="-u ntp:ntp"
+
+                `/etc/init.d/ntp`:
+
+                RUNASUSER=ntp
+          - check:
+              audit: "grep ^OPTIONS /etc/default/ntp"
+              constraints:
+                platform:
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: 'OPTIONS="-u ntp:ntp"'
+                    set: true
+              remediation: |
+                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
+
+                restrict -4 default kod nomodify notrap nopeer noquery
+                restrict -6 default kod nomodify notrap nopeer noquery
+
+                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
+
+                server
+
+                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
+                `/etc/default/ntp` :
+
+                OPTIONS="-u ntp:ntp"
+
+                `/etc/default/ntp` :
+
+                NTPD_OPTIONS="-u ntp:ntp"
+
+                `/etc/init.d/ntp`:
+
+                RUNASUSER=ntp
+        scored: true
+
+      - id: 2.2.1.2.d
+        description: "Ensure ntp is configured"
+        sub_checks:
+          - check:
+              audit: "grep ^NTPD_OPTIONS /etc/sysconfig/ntp"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: 'NTPD_OPTIONS="-u ntp:ntp"'
+                    set: true
+              remediation: |
+                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
+
+                restrict -4 default kod nomodify notrap nopeer noquery
+                restrict -6 default kod nomodify notrap nopeer noquery
+
+                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
+
+                server
+
+                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
+                `/etc/sysconfig/ntpd` :
+
+                OPTIONS="-u ntp:ntp"
+
+                `/etc/sysconfig/ntp` :
+
+                NTPD_OPTIONS="-u ntp:ntp"
+
+                `/etc/init.d/ntp`:
+
+                RUNASUSER=ntp
+          - check:
+              audit: "grep ^NTPD_OPTIONS /etc/default/ntp"
+              constraints:
+                platform:
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: 'NTPD_OPTIONS="-u ntp:ntp"'
+                    set: true
+              remediation: |
+                Add or edit restrict lines in `/etc/ntp.conf` to match the following:
+
+                restrict -4 default kod nomodify notrap nopeer noquery
+                restrict -6 default kod nomodify notrap nopeer noquery
+
+                Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
+
+                server
+
+                Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
+                `/etc/default/ntp` :
+
+                OPTIONS="-u ntp:ntp"
+
+                `/etc/default/ntp` :
+
+                NTPD_OPTIONS="-u ntp:ntp"
+
+                `/etc/init.d/ntp`:
+
+                RUNASUSER=ntp
+        scored: true
+
+      - id: 2.2.1.2.e
+        description: "Ensure ntp is configured"
+        audit: "grep RUNASUSER=ntp /etc/init.d/ntp"
+        tests:
+          test_items:
+            - flag: "RUNASUSER"
+              compare:
+                op: eq
+                value: "ntp"
+              set: true
+        remediation: |
+          Add or edit restrict lines in `/etc/ntp.conf` to match the following:
+
+          restrict -4 default kod nomodify notrap nopeer noquery
+          restrict -6 default kod nomodify notrap nopeer noquery
+
+          Add or edit server or pool lines to `/etc/ntp.conf` as appropriate:
+
+          server
+
+          Configure `ntp` to run as the `ntp` user by adding or editing one of the following files as appropriate for your distribution:
+          `/etc/sysconfig/ntpd` :
+
+          OPTIONS="-u ntp:ntp"
+
+          `/etc/sysconfig/ntp` :
+
+          NTPD_OPTIONS="-u ntp:ntp"
+
+          `/etc/init.d/ntp`:
+
+          RUNASUSER=ntp
+
+        scored: true
+
+      - id: 2.2.1.3.a
+        description: "Ensure chrony is configured"
+        audit: 'grep -E "^(server|pool)" /etc/chrony.conf'
+        type: manual
+        tests:
+          test_items:
+            - flag: "server <remote-server>"
+              set: true
+        remediation: |
+          Add or edit server or pool lines to `/etc/chrony.conf` as appropriate:
+
+          server
+
+          Configure `chrony` to run as the `chrony` user by configuring the appropriate startup script for your distribution. Startup scripts are typically stored in `/etc/init.d` or `/etc/systemd`.
+        scored: true
+
+      - id: 2.2.1.3.b
+        description: "Ensure chrony is configured"
+        audit: "ps -ef | grep chronyd"
+        type: manual
+        remediation: |
+          Add or edit server or pool lines to `/etc/chrony.conf` as appropriate:
+
+          server
+
+          Configure `chrony` to run as the `chrony` user by configuring the appropriate startup script for your distribution. Startup scripts are typically stored in `/etc/init.d` or `/etc/systemd`.
+        scored: true
+      - id: 2.2.1.4.a
+        description: "Ensure ntp is configured"
+        audit: "systemctl is-enabled systemd-timesyncd.service"
+        tests:
+          test_items:
+            - flag: "enabled"
+              set: true
+        remediation: |
+          Run the following command to enable systemd-timesyncd
+          systemctl enable systemd-timesyncd.service
+          edit the file /etc/systemd/timesyncd.conf and add/modify the following lines:
+          NTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy
+          FallbackNTP=2.debian.pool.ntp.org 3.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy
+          RootDistanceMax=1 #should be In Accordence With Local Policy
+          Run the following commands to start systemd-timesyncd.service
+          # systemctl start systemd-timesyncd.service
+          # timedatectl set-ntp true
+        scored: true
+
+      - id: 2.2.1.4.b
+        description: "Ensure ntp is configured"
+        audit: "timedatectl status"
+        type: manual
+        remediation: |
+          Run the following command to enable systemd-timesyncd
+          systemctl enable systemd-timesyncd.service
+          edit the file /etc/systemd/timesyncd.conf and add/modify the following lines:
+          NTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy
+          FallbackNTP=2.debian.pool.ntp.org 3.debian.pool.ntp.org #Servers listed should be In Accordence With Local Policy
+          RootDistanceMax=1 #should be In Accordence With Local Policy
+          Run the following commands to start systemd-timesyncd.service
+          # systemctl start systemd-timesyncd.service
+          # timedatectl set-ntp true
+        scored: true
+
+      - id: 2.2.2
+        description: "Ensure X Window System is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q xorg-x11*"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
+                Remove the X Windows System packages using the appropriate package manager or manual installation:
+
+                yum remove xorg-x11*
+
+
+                apt-get remove xserver-xorg*
+
+
+                zypper remove xorg-x11*
+          - check:
+              audit: "dpkg -l xserver-xorg*"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "ii"
+                    set: false
+              remediation: |
+                Remove the X Windows System packages using the appropriate package manager or manual installation:
+
+                yum remove xorg-x11*
+
+
+                apt-get remove xserver-xorg*
+
+
+                zypper remove xorg-x11*
+          - check:
+              audit: "apt-cache policy xserver-xorg* | grep Installed -B1"
+              use_multiple_values: true
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                bin_op: or
+                test_items:
+                  - flag: "Installed"
+                    compare:
+                      op: eq
+                      value: "(none)"
+                    set: true
+                  - flag: "Installed"
+                    set: false
+              remediation: |
+                Remove the X Windows System packages using the appropriate package manager or manual installation:
+
+                yum remove xorg-x11*
+
+
+                apt-get remove xserver-xorg*
+
+
+                zypper remove xorg-x11*
+        scored: true
+      - id: 2.2.3
+        description: "Ensure Avahi service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list avahi-daemon"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "avahi-daemon 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `avahi-daemon` :
+
+                # chkconfig avahi-daemon off
+
+
+                # systemctl disable avahi-daemon
+
+
+                # update-rc.d avahi-daemon disable
+          - check:
+              audit: "systemctl is-enabled avahi-daemon"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `avahi-daemon` :
+
+                # chkconfig avahi-daemon off
+
+
+                # systemctl disable avahi-daemon
+
+
+                # update-rc.d avahi-daemon disable
+          - check:
+              audit: "ls /etc/rc*.d | grep avahi-daemon"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `avahi-daemon` :
+
+                # chkconfig avahi-daemon off
+
+
+                # systemctl disable avahi-daemon
+
+
+                # update-rc.d avahi-daemon disable
+        scored: true
+      - id: 2.2.4
+        description: "Ensure cups service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list cups"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "cups 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `cups` :
+
+                # chkconfig cups off
+
+
+                # systemctl disable cups
+
+
+                # update-rc.d cups disable
+          - check:
+              audit: "systemctl is-enabled cups"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `cups` :
+
+                # chkconfig cups off
+
+
+                # systemctl disable cups
+
+
+                # update-rc.d cups disable
+          - check:
+              audit: "ls /etc/rc*.d | grep cups"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `cups` :
+
+                # chkconfig cups off
+
+
+                # systemctl disable cups
+
+
+                # update-rc.d cups disable
+        scored: true
+      - id: 2.2.5
+        description: "Ensure DHCP service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list dhcpd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "dhcpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `dhcpd` :
+
+                # chkconfig dhcpd off
+
+
+                # systemctl disable dhcpd
+
+
+                # update-rc.d dhcpd disable
+          - check:
+              audit: "systemctl is-enabled dhcpd"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `dhcpd` :
+
+                # chkconfig dhcpd off
+
+
+                # systemctl disable dhcpd
+
+
+                # update-rc.d dhcpd disable
+          - check:
+              audit: "ls /etc/rc*.d | grep dhcpd"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `dhcpd` :
+
+                # chkconfig dhcpd off
+
+
+                # systemctl disable dhcpd
+
+
+                # update-rc.d dhcpd disable
+        scored: true
+      - id: 2.2.6
+        description: "Ensure LDAP service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list slapd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "slapd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `slapd` :
+
+                # chkconfig slapd off
+
+
+                # systemctl disable slapd
+
+
+                # update-rc.d slapd disable
+          - check:
+              audit: "systemctl is-enabled slapd"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `slapd` :
+
+                # chkconfig slapd off
+
+
+                # systemctl disable slapd
+
+
+                # update-rc.d slapd disable
+          - check:
+              audit: "ls /etc/rc*.d | grep slapd"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `slapd` :
+
+                # chkconfig slapd off
+
+
+                # systemctl disable slapd
+
+
+                # update-rc.d slapd disable
+        scored: true
+
+      - id: 2.2.7.a
+        description: "Ensure NFS and RPC are not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list nfs"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "nfs 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `nfs` :
+
+                # chkconfig nfs off
+
+
+                # systemctl disable nfs
+
+
+                # update-rc.d nfs disable
+          - check:
+              audit: "systemctl is-enabled nfs"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `nfs` :
+
+                # chkconfig nfs off
+
+
+                # systemctl disable nfs
+
+
+                # update-rc.d nfs disable
+          - check:
+              audit: "ls /etc/rc*.d | grep nfs"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `nfs` :
+
+                # chkconfig nfs off
+
+
+                # systemctl disable nfs
+
+
+                # update-rc.d nfs disable
+        scored: true
+
+      - id: 2.2.7.b
+        description: "Ensure NFS and RPC are not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list rpcbind"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "rpcbind 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `rpcbind` :
+
+                # chkconfig rpcbind off
+
+
+                # systemctl disable rpcbind
+
+
+                # update-rc.d rpcbind disable
+          - check:
+              audit: "systemctl is-enabled rpcbind"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `rpcbind` :
+
+                # chkconfig rpcbind off
+
+
+                # systemctl disable rpcbind
+
+
+                # update-rc.d rpcbind disable
+          - check:
+              audit: "ls /etc/rc*.d | grep rpcbind"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "rpcbind"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `rpcbind` :
+
+                # chkconfig rpcbind off
+
+
+                # systemctl disable rpcbind
+
+
+                # update-rc.d rpcbind disable
+        scored: true
+
+      - id: 2.2.8
+        description: "Ensure DNS service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list named"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "named 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `named` :
+
+                # chkconfig named off
+
+
+                # systemctl disable named
+
+
+                # update-rc.d named disable
+          - check:
+              audit: "systemctl is-enabled named"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `named` :
+
+                # chkconfig named off
+
+
+                # systemctl disable named
+
+
+                # update-rc.d named disable
+          - check:
+              audit: "ls /etc/rc*.d | grep named"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "named"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `named` :
+
+                # chkconfig named off
+
+
+                # systemctl disable named
+
+
+                # update-rc.d named disable
+        scored: true
+      - id: 2.2.9
+        description: "Ensure FTP service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list vsftpd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "vsftpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `vsftpd` :
+
+                # chkconfig vsftpd off
+
+
+                # systemctl disable vsftpd
+
+
+                # update-rc.d vsftpd disable
+          - check:
+              audit: "systemctl is-enabled vsftpd"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `vsftpd` :
+
+                # chkconfig vsftpd off
+
+
+                # systemctl disable vsftpd
+
+
+                # update-rc.d vsftpd disable
+          - check:
+              audit: "ls /etc/rc*.d | grep vsftpd"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "vsftpd"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `vsftpd` :
+
+                # chkconfig vsftpd off
+
+
+                # systemctl disable vsftpd
+
+
+                # update-rc.d vsftpd disable
+        scored: true
+      - id: 2.2.10
+        description: "Ensure HTTP service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list httpd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "httpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `httpd` :
+
+                # chkconfig httpd off
+
+
+                # systemctl disable httpd
+
+
+                # update-rc.d httpd disable
+          - check:
+              audit: "systemctl is-enabled httpd"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `httpd` :
+
+                # chkconfig httpd off
+
+
+                # systemctl disable httpd
+
+
+                # update-rc.d httpd disable
+          - check:
+              audit: "ls /etc/rc*.d | grep httpd"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "httpd"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `httpd` :
+
+                # chkconfig httpd off
+
+
+                # systemctl disable httpd
+
+
+                # update-rc.d httpd disable
+        scored: true
+      - id: 2.2.11
+        description: "Ensure IMAP and POP3 service are not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list dovecot"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "dovecot 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `dovecot` :
+
+                # chkconfig dovecot off
+
+
+                # systemctl disable dovecot
+
+
+                # update-rc.d dovecot disable
+          - check:
+              audit: "systemctl is-enabled dovecot"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `dovecot` :
+
+                # chkconfig dovecot off
+
+
+                # systemctl disable dovecot
+
+
+                # update-rc.d dovecot disable
+          - check:
+              audit: "ls /etc/rc*.d | grep dovecot"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "dovecot"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `dovecot` :
+
+                # chkconfig dovecot off
+
+
+                # systemctl disable dovecot
+
+
+                # update-rc.d dovecot disable
+        scored: true
+      - id: 2.2.12
+        description: "Ensure Samba is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list smb"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "smb 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `smb` :
+
+                # chkconfig smb off
+
+
+                # systemctl disable smb
+
+
+                # update-rc.d smb disable
+          - check:
+              audit: "systemctl is-enabled smb"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `smb` :
+
+                # chkconfig smb off
+
+
+                # systemctl disable smb
+
+
+                # update-rc.d smb disable
+          - check:
+              audit: "ls /etc/rc*.d | grep smb"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "smb"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `smb` :
+
+                # chkconfig smb off
+
+
+                # systemctl disable smb
+
+
+                # update-rc.d smb disable
+        scored: true
+      - id: 2.2.13
+        description: "Ensure HTTP Proxy Server is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list squid"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "squid 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `squid` :
+
+                # chkconfig squid off
+
+
+                # systemctl disable squid
+
+
+                # update-rc.d squid disable
+          - check:
+              audit: "systemctl is-enabled squid"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `squid` :
+
+                # chkconfig squid off
+
+
+                # systemctl disable squid
+
+
+                # update-rc.d squid disable
+          - check:
+              audit: "ls /etc/rc*.d | grep squid"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "squid"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `squid` :
+
+                # chkconfig squid off
+
+
+                # systemctl disable squid
+
+
+                # update-rc.d squid disable
+        scored: true
+      - id: 2.2.14
+        description: "Ensure SNMP Server is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list snmpd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "snmpd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `snmpd` :
+
+                # chkconfig snmpd off
+
+
+                # systemctl disable snmpd
+
+
+                # update-rc.d snmpd disable
+          - check:
+              audit: "systemctl is-enabled snmpd"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `snmpd` :
+
+                # chkconfig snmpd off
+
+
+                # systemctl disable snmpd
+
+
+                # update-rc.d snmpd disable
+          - check:
+              audit: "ls /etc/rc*.d | grep snmpd"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "snmpd"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `snmpd` :
+
+                # chkconfig snmpd off
+
+
+                # systemctl disable snmpd
+
+
+                # update-rc.d snmpd disable
+        scored: true
+      - id: 2.2.15
+        description: "Ensure mail transfer agent is configured for local-only mode"
+        audit: |
+          ss -lntu | grep -E ':25\\s' | grep -E -v '\\s(127.0.0.1|::1):25\\s'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit `/etc/postfix/main.cf` and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below:
+
+          inet_interfaces = loopback-only
+
+          Restart postfix with one of the following commands:
+
+          # service postfix restart
+          # systemctl restart postfix
+
+        scored: true
+
+      - id: 2.2.16
+        description: "Ensure rsync service is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list rsyncd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "rsyncd 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `rsyncd` :
+
+                # chkconfig rsyncd off
+
+
+                # systemctl disable rsyncd
+
+
+                # update-rc.d rsyncd disable
+          - check:
+              audit: "systemctl is-enabled rsyncd"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `rsyncd` :
+
+                # chkconfig rsyncd off
+
+
+                # systemctl disable rsyncd
+
+
+                # update-rc.d rsyncd disable
+          - check:
+              audit: "ls /etc/rc*.d | grep rsyncd"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "rsyncd"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `rsyncd` :
+
+                # chkconfig rsyncd off
+
+
+                # systemctl disable rsyncd
+
+
+                # update-rc.d rsyncd disable
+        scored: true
+      - id: 2.2.17
+        description: "Ensure NIS Server is not enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list ypserv"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "ypserv 0:off 1:off 2:off 3:off 4:off 5:off 6:off"
+                    set: true
+              remediation: |
+                Run one of the following commands to disable `ypserv` :
+
+                # chkconfig ypserv off
+
+
+                # systemctl disable ypserv
+
+
+                # update-rc.d ypserv disable
+          - check:
+              audit: "systemctl is-enabled ypserv"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `ypserv` :
+
+                # chkconfig ypserv off
+
+
+                # systemctl disable ypserv
+
+
+                # update-rc.d ypserv disable
+          - check:
+              audit: "ls /etc/rc*.d | grep ypserv"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: "ypserv"
+                    set: false
+              remediation: |
+                Run one of the following commands to disable `ypserv` :
+
+                # chkconfig ypserv off
+
+
+                # systemctl disable ypserv
+
+
+                # update-rc.d ypserv disable
+        scored: true
+
+  - id: 2.3
+    description: "Service Clients"
+    checks:
+      - id: 2.3.1
+        description: "Ensure NIS Client is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q ypbind"
+              constraints:
+                platform:
+                  - rhel7
+
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
                 Uninstall `ypbind` using the appropriate package manager or manual installation:
-            
+
                 yum remove ypbind
-                
-                
+
+
                 apt-get remove ypbind
-                
-                
+
+
                 zypper remove ypbind
-      - check:
-          audit: "dpkg -s ypbind"   
-          constraints:          
-            platform:
-            - ubuntu16
-          tests:
-            test_items:        
-            - flag: "install ok installed"  
-              set: false
-          remediation: |
-               Uninstall `ypbind` using the appropriate package manager or manual installation:
-            
-                yum remove ypbind
-                
-                
-                apt-get remove ypbind
-                
-                
-                zypper remove ypbind
-          set: true                                     
-      - check:
-          audit: "apt-cache show ypbind"   
-          constraints:          
-            platform:
-            - ubuntu18
-          tests:
-            test_items:        
-            - flag: "Installed-Size:"  
-              set: false
-          remediation: |
-               Uninstall `ypbind` using the appropriate package manager or manual installation:
-            
-                yum remove ypbind
-                
-                
-                apt-get remove ypbind
-                
-                
-                zypper remove ypbind
-          set: true
-      scored: true                        
-    - id: 2.3.2
-      description: "Ensure rsh client is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q rsh"   
-          constraints:          
-            platform:
-            - rhel7
-          
-          tests:
-            test_items:        
-            - flag: "is not installed"  
+          - check:
+              audit: "dpkg -s ypbind"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: false
+              remediation: |
+                Uninstall `ypbind` using the appropriate package manager or manual installation:
+
+                 yum remove ypbind
+
+
+                 apt-get remove ypbind
+
+
+                 zypper remove ypbind
               set: true
-          remediation: |
+          - check:
+              audit: "apt-cache show ypbind"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
+                Uninstall `ypbind` using the appropriate package manager or manual installation:
+
+                 yum remove ypbind
+
+
+                 apt-get remove ypbind
+
+
+                 zypper remove ypbind
+              set: true
+        scored: true
+      - id: 2.3.2
+        description: "Ensure rsh client is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q rsh"
+              constraints:
+                platform:
+                  - rhel7
+
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
                 Uninstall `rsh` using the appropriate package manager or manual installation:
-            
+
                 yum remove rsh
-                
-                
+
+
                 apt-get remove rsh
-                
-                
+
+
                 zypper remove rsh
-      - check:
-          audit: "dpkg -s rsh-client rsh-redone-client"   
-          constraints:          
-            platform:
-            - ubuntu16
-          tests:
-            test_items:        
-            - flag: "install ok installed"  
-              set: false
-          remediation: |
-               Uninstall `rsh` using the appropriate package manager or manual installation:
-            
-                yum remove rsh
-                
-                
-                apt-get remove rsh
-                
-                
-                zypper remove rsh
-          set: true                                     
-      - check:
-          audit: "apt-cache show rsh-client rsh-redone-client"   
-          constraints:          
-            platform:
-            - ubuntu18
-          tests:
-            test_items:        
-            - flag: "Installed-Size:"  
-              set: false
-          remediation: |
-               Uninstall `rsh` using the appropriate package manager or manual installation:
-            
-                yum remove rsh
-                
-                
-                apt-get remove rsh
-                
-                
-                zypper remove rsh
-          set: true
-      scored: true    
-    - id: 2.3.3
-      description: "Ensure talk client is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q talk"   
-          constraints:          
-            platform:
-            - rhel7
-          
-          tests:
-            test_items:        
-            - flag: "is not installed"  
+          - check:
+              audit: "dpkg -s rsh-client rsh-redone-client"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: false
+              remediation: |
+                Uninstall `rsh` using the appropriate package manager or manual installation:
+
+                 yum remove rsh
+
+
+                 apt-get remove rsh
+
+
+                 zypper remove rsh
               set: true
-          remediation: |
+          - check:
+              audit: "apt-cache show rsh-client rsh-redone-client"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
+                Uninstall `rsh` using the appropriate package manager or manual installation:
+
+                 yum remove rsh
+
+
+                 apt-get remove rsh
+
+
+                 zypper remove rsh
+              set: true
+        scored: true
+      - id: 2.3.3
+        description: "Ensure talk client is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q talk"
+              constraints:
+                platform:
+                  - rhel7
+
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
                 Uninstall `talk` using the appropriate package manager or manual installation:
-            
+
                 yum remove talk
-            
-            
+
+
                 apt-get remove talk
-            
-            
+
+
                 zypper remove talk
-      - check:
-          audit: "dpkg -s talk"   
-          constraints:          
-            platform:
-            - ubuntu16
-          tests:
-            test_items:        
-            - flag: "install ok installed"  
-              set: false
-          remediation: |
+          - check:
+              audit: "dpkg -s talk"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: false
+              remediation: |
                 Uninstall `talk` using the appropriate package manager or manual installation:
-            
+
                 yum remove talk
-            
-            
+
+
                 apt-get remove talk
-            
-            
+
+
                 zypper remove talk
-      - check:
-          audit: "apt-cache show talk"   
-          constraints:          
-            platform:
-            - ubuntu18
-          tests:
-            test_items:        
-            - flag: "Installed-Size:"  
-              set: false
-          remediation: |
+          - check:
+              audit: "apt-cache show talk"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
                 Uninstall `talk` using the appropriate package manager or manual installation:
-            
+
                 yum remove talk
-            
-            
+
+
                 apt-get remove talk
-            
-            
+
+
                 zypper remove talk
-      scored: true
-    - id: 2.3.4
-      description: "Ensure telnet client is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q telnet"   
-          constraints:          
-            platform:
-            - rhel7
-          
-          tests:
-            test_items:        
-            - flag: "package telnet is not installed"  
-              set: true
-          remediation: |
+        scored: true
+      - id: 2.3.4
+        description: "Ensure telnet client is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q telnet"
+              constraints:
+                platform:
+                  - rhel7
+
+              tests:
+                test_items:
+                  - flag: "package telnet is not installed"
+                    set: true
+              remediation: |
                 Uninstall `telnet` using the appropriate package manager or manual installation:
-                
+
                 # yum remove telnet
-                
-                
+
+
                 # apt-get remove telnet
-                
-                
+
+
                 # zypper remove telnet
-      - check:
-          audit: "dpkg -s telnet"   
-          constraints:          
-            platform:
-            - ubuntu16
-          tests:
-            test_items:        
-            - flag: "install ok installed"  
-              set: false
-          remediation: |
+          - check:
+              audit: "dpkg -s telnet"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: false
+              remediation: |
                 Uninstall `telnet` using the appropriate package manager or manual installation:
-                
+
                 # yum remove telnet
-                
-                
+
+
                 # apt-get remove telnet
-                
-                
+
+
                 # zypper remove telnet
-      - check:
-          audit: "apt-cache show telnet"   
-          constraints:          
-            platform:
-            - ubuntu18
-          tests:
-            test_items:        
-            - flag: "Installed-Size:"  
-              set: false
-          remediation: |
+          - check:
+              audit: "apt-cache show telnet"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
                 Uninstall `telnet` using the appropriate package manager or manual installation:
-                
+
                 # yum remove telnet
-                
-                
+
+
                 # apt-get remove telnet
-                
-                
+
+
                 # zypper remove telnet
-      scored: true        
-    - id: 2.3.5
-      description: "Ensure LDAP client is not installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q openldap-clients"   
-          constraints:          
-            platform:
-            - rhel7
-          tests:
-            test_items:        
-            - flag: "is not installed"
-              set: true
-          remediation: |
+        scored: true
+      - id: 2.3.5
+        description: "Ensure LDAP client is not installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q openldap-clients"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: true
+              remediation: |
                 Uninstall `openldap-clients` using the appropriate package manager or manual installation:
-                
+
                 # yum remove openldap-clients
-                
-                
+
+
                 # apt-get remove openldap-clients
-                
-                
+
+
                 # zypper remove openldap-clients
-      - check:
-          audit: "dpkg -s openldap-clients"   
-          constraints:          
-            platform:
-            - ubuntu16
-          tests:
-            test_items:        
-            - flag: "install ok installed"
-              set: false
-          remediation: |
+          - check:
+              audit: "dpkg -s openldap-clients"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: false
+              remediation: |
                 Uninstall `openldap-clients` using the appropriate package manager or manual installation:
-                
+
                 # yum remove openldap-clients
-                
-                
+
+
                 # apt-get remove openldap-clients
-                
-                
+
+
                 # zypper remove openldap-clients
-      - check:
-          audit: "apt-cache show openldap-clients"   
-          constraints:          
-            platform:
-            - ubuntu18
-          tests:
-            test_items:        
-            - flag: "Installed-Size:"
-              set: false
-          remediation: |
+          - check:
+              audit: "apt-cache show openldap-clients"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: false
+              remediation: |
                 Uninstall `openldap-clients` using the appropriate package manager or manual installation:
-                
+
                 # yum remove openldap-clients
-                
-                
+
+
                 # apt-get remove openldap-clients
-                
-                
+
+
                 # zypper remove openldap-clients
-      scored: true                  
-- id: 3
-  description: "Network Configuration"
-- id: 3.1
-  description: "Network Parameters (Host Only)etwork Parameters (Host Only)"
-  checks:
-    - id: 3.1.1.a
-      description: "Ensure IP forwarding is disabled"
-      audit: "sysctl net.ipv4.ip_forward"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.ip_forward"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.ip_forward = 0
-            net.ipv6.conf.all.forwarding = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.ip_forward=0
-            # sysctl -w net.ipv6.conf.all.forwarding=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.1.1.b
-      description: "Ensure IP forwarding is disabled"
-      audit: "grep ^\\s*\"net\\.ipv4\\.ip_forward\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.ip_forward"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.ip_forward = 0
-            net.ipv6.conf.all.forwarding = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.ip_forward=0
-            # sysctl -w net.ipv6.conf.all.forwarding=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-    - id: 3.1.1.c
-      description: "Ensure IP forwarding is disabled"
-      audit: "sysctl net.ipv6.conf.all.forwarding"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.forwarding"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.ip_forward = 0
-            net.ipv6.conf.all.forwarding = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.ip_forward=0
-            # sysctl -w net.ipv6.conf.all.forwarding=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true
-    - id: 3.1.1.d
-      description: "Ensure IP forwarding is disabled"
-      audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.forwarding\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.forwarding"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.ip_forward = 0
-            net.ipv6.conf.all.forwarding = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.ip_forward=0
-            # sysctl -w net.ipv6.conf.all.forwarding=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true  
-    - id: 3.1.2.a
-      description: "Ensure packet redirect sending is disabled"
-      audit: "sysctl net.ipv4.conf.all.send_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.send_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.send_redirects = 0
-            net.ipv4.conf.default.send_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.send_redirects=0
-            # sysctl -w net.ipv4.conf.default.send_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.1.2.b
-      description: "Ensure packet redirect sending is disabled"
-      audit: "sysctl net.ipv4.conf.default.send_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.send_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.send_redirects = 0
-            net.ipv4.conf.default.send_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.send_redirects=0
-            # sysctl -w net.ipv4.conf.default.send_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.1.2.c
-      description: "Ensure packet redirect sending is disabled"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.send_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.send_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.send_redirects = 0
-            net.ipv4.conf.default.send_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.send_redirects=0
-            # sysctl -w net.ipv4.conf.default.send_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.1.2.d
-      description: "Ensure packet redirect sending is disabled"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.send_redirects /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.send_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.send_redirects = 0
-            net.ipv4.conf.default.send_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.send_redirects=0
-            # sysctl -w net.ipv4.conf.default.send_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-        
-- id: 3.2
-  description: "Network Parameters (Host and Router)"
-  checks:
-    - id: 3.2.1.a
-      description: "Ensure source routed packets are not accepted"
-      audit: "sysctl net.ipv4.conf.all.accept_source_route"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.accept_source_route"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.1.b
-      description: "Ensure source routed packets are not accepted"
-      audit: "sysctl net.ipv4.conf.default.accept_source_route"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.accept_source_route"
-          compare:
-            op: eq
-            value: 0
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.1.c
-      description: "Ensure source routed packets are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.accept_source_route"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.1.d
-      description: "Ensure source routed packets are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.accept_source_route"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.1.e
-      description: "Ensure packet redirect sending is disabled"
-      audit: "sysctl net.ipv6.conf.all.accept_source_route"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.accept_source_route"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.1.f
-      description: "Ensure packet redirect sending is disabled"
-      audit: "sysctl net.ipv6.conf.default.accept_source_route"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.default.accept_source_route"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.1.g
-      description: "Ensure packet redirect sending is disabled"
-      audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.accept_source_route"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.1.h
-      description: "Ensure packet redirect sending is disabled"
-      audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.default\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.default.accept_source_route"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_source_route = 0
-            net.ipv4.conf.default.accept_source_route = 0
-            net.ipv6.conf.all.accept_source_route = 0 
-            net.ipv6.conf.default.accept_source_route = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_source_route=0
-            # sysctl -w net.ipv4.conf.default.accept_source_route=0
-            # sysctl -w net.ipv6.conf.all.accept_source_route=0 
-            # sysctl -w net.ipv6.conf.default.accept_source_route=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-
-    - id: 3.2.2.a
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "sysctl net.ipv4.conf.all.accept_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.2.b
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "sysctl net.ipv4.conf.default.accept_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.2.c
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.2.d
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.2.e
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "sysctl net.ipv6.conf.all.accept_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.2.f
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "sysctl net.ipv6.conf.default.accept_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.default.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.2.g
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.2.h
-      description: "Ensure ICMP redirects are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.default\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.default.accept_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.accept_redirects = 0
-            net.ipv4.conf.default.accept_redirects = 0
-            net.ipv6.conf.all.accept_redirects = 0 
-            net.ipv6.conf.default.accept_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.accept_redirects=0
-            # sysctl -w net.ipv4.conf.default.accept_redirects=0
-            # sysctl -w net.ipv6.conf.all.accept_redirects=0 
-            # sysctl -w net.ipv6.conf.default.accept_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    
-    - id: 3.2.3.a
-      description: "Ensure secure ICMP redirects are not accepted"
-      audit: "sysctl net.ipv4.conf.all.secure_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.secure_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.secure_redirects = 0
-            net.ipv4.conf.default.secure_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.secure_redirects=0
-            # sysctl -w net.ipv4.conf.default.secure_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.3.b
-      description: "Ensure secure ICMP redirects are not accepted"
-      audit: "sysctl net.ipv4.conf.default.secure_redirects"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.secure_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.secure_redirects = 0
-            net.ipv4.conf.default.secure_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.secure_redirects=0
-            # sysctl -w net.ipv4.conf.default.secure_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.3.c
-      description: "Ensure secure ICMP redirects are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.secure_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.secure_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.secure_redirects = 0
-            net.ipv4.conf.default.secure_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.secure_redirects=0
-            # sysctl -w net.ipv4.conf.default.secure_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.3.d
-      description: "Ensure secure ICMP redirects are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.secure_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.secure_redirects"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.secure_redirects = 0
-            net.ipv4.conf.default.secure_redirects = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.secure_redirects=0
-            # sysctl -w net.ipv4.conf.default.secure_redirects=0
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.4.a
-      description: "Ensure suspicious packets are logged"
-      audit: "sysctl net.ipv4.conf.all.log_martians"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.log_martians"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.log_martians = 1
-            net.ipv4.conf.default.log_martians = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.log_martians=1
-            # sysctl -w net.ipv4.conf.default.log_martians=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.4.b
-      description: "Ensure suspicious packets are logged"
-      audit: "sysctl net.ipv4.conf.default.log_martians"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.log_martians"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.log_martians = 1
-            net.ipv4.conf.default.log_martians = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.log_martians=1
-            # sysctl -w net.ipv4.conf.default.log_martians=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.4.c
-      description: "Ensure suspicious packets are logged"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.log_martians\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.log_martians"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.log_martians = 1
-            net.ipv4.conf.default.log_martians = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.log_martians=1
-            # sysctl -w net.ipv4.conf.default.log_martians=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.4.d
-      description: "Ensure suspicious packets are logged"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.log_martians\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.log_martians"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.log_martians = 1
-            net.ipv4.conf.default.log_martians = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.log_martians=1
-            # sysctl -w net.ipv4.conf.default.log_martians=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.5.a
-      description: "Ensure broadcast ICMP requests are ignored"
-      audit: "sysctl net.ipv4.icmp_echo_ignore_broadcasts"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.icmp_echo_ignore_broadcasts"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.icmp_echo_ignore_broadcasts = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.5.b
-      description: "Ensure broadcast ICMP requests are ignored"
-      audit: "grep ^\\s*\"net\\.ipv4\\.icmp_echo_ignore_broadcasts\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.icmp_echo_ignore_broadcasts"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.icmp_echo_ignore_broadcasts = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.6.a
-      description: "Ensure bogus ICMP responses are ignored"
-      audit: "sysctl net.ipv4.icmp_ignore_bogus_error_responses"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.icmp_ignore_bogus_error_responses"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.icmp_ignore_bogus_error_responses = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.6.b
-      description: "Ensure bogus ICMP responses are ignored"
-      audit: "grep ^\\s*\"net\\.ipv4\\.icmp_ignore_bogus_error_responses\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.icmp_ignore_bogus_error_responses"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.icmp_ignore_bogus_error_responses = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.7.a
-      description: "Ensure Reverse Path Filtering is enabled"
-      audit: "sysctl net.ipv4.conf.all.rp_filter"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.rp_filter"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.rp_filter = 1
-            net.ipv4.conf.default.rp_filter = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.rp_filter=1
-            # sysctl -w net.ipv4.conf.default.rp_filter=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.7.b
-      description: "Ensure Reverse Path Filtering is enabled"
-      audit: "sysctl net.ipv4.conf.default.rp_filter"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.rp_filter"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.rp_filter = 1
-            net.ipv4.conf.default.rp_filter = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.rp_filter=1
-            # sysctl -w net.ipv4.conf.default.rp_filter=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.7.c
-      description: "Ensure Reverse Path Filtering is enabled"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.rp_filter\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.all.rp_filter"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.rp_filter = 1
-            net.ipv4.conf.default.rp_filter = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.rp_filter=1
-            # sysctl -w net.ipv4.conf.default.rp_filter=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.7.d
-      description: "Ensure Reverse Path Filtering is enabled"
-      audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.rp_filter\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.conf.default.rp_filter"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.conf.all.rp_filter = 1
-            net.ipv4.conf.default.rp_filter = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.conf.all.rp_filter=1
-            # sysctl -w net.ipv4.conf.default.rp_filter=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.8.a
-      description: "Ensure TCP SYN Cookies is enabled"
-      audit: "sysctl net.ipv4.tcp_syncookies"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.tcp_syncookies"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.tcp_syncookies = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.tcp_syncookies=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.8.b
-      description: "Ensure TCP SYN Cookies is enabled"
-      audit: "grep ^\\s*\"net\\.ipv4\\.tcp_syncookies\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv4.tcp_syncookies"
-          compare:
-            op: eq
-            value: "1"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv4.tcp_syncookies = 1
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv4.tcp_syncookies=1
-            # sysctl -w net.ipv4.route.flush=1
-            
-      scored: true                  
-    
-    - id: 3.2.9.a
-      description: "Ensure IPv6 router advertisements are not accepted"
-      audit: "sysctl net.ipv6.conf.all.accept_ra"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.accept_ra"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv6.conf.all.accept_ra = 0
-            net.ipv6.conf.default.accept_ra = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv6.conf.all.accept_ra=0
-            # sysctl -w net.ipv6.conf.default.accept_ra=0
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.9.b
-      description: "Ensure IPv6 router advertisements are not accepted"
-      audit: "sysctl net.ipv6.conf.default.accept_ra"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.default.accept_ra"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv6.conf.all.accept_ra = 0
-            net.ipv6.conf.default.accept_ra = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv6.conf.all.accept_ra=0
-            # sysctl -w net.ipv6.conf.default.accept_ra=0
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.9.c
-      description: "Ensure IPv6 router advertisements are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.accept_ra\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.all.accept_ra"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv6.conf.all.accept_ra = 0
-            net.ipv6.conf.default.accept_ra = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv6.conf.all.accept_ra=0
-            # sysctl -w net.ipv6.conf.default.accept_ra=0
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true                  
-            
-    - id: 3.2.9.d
-      description: "Ensure IPv6 router advertisements are not accepted"
-      audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.default\\.accept_ra\" /etc/sysctl.conf /etc/sysctl.d/*"   
-      tests:
-        test_items:
-        - flag: "net.ipv6.conf.default.accept_ra"
-          compare:
-            op: eq
-            value: "0"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
-            
-            net.ipv6.conf.all.accept_ra = 0
-            net.ipv6.conf.default.accept_ra = 0
-            
-            Run the following commands to set the active kernel parameters:
-            
-            # sysctl -w net.ipv6.conf.all.accept_ra=0
-            # sysctl -w net.ipv6.conf.default.accept_ra=0
-            # sysctl -w net.ipv6.route.flush=1
-            
-      scored: true 
-
-- id: 3.3
-  description: "TCP Wrappers"
-  checks:
-    - id: 3.3.1
-      description: "Ensure TCP Wrappers is installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q tcp_wrappers"   
-          constraints:          
-            platform:
-            - rhel7
-          tests:  
-            test_items:
-            - flag: "is not installed"
-              set: false
-          remediation: |
-                Install TCP Wrappers using the appropriate package manager or manual installation:
-                
-                yum install tcp_wrappers
-                
-                
-                apt-get install tcpd
-                
-                
-                zypper install tcpd
-      - check:
-          audit: "dpkg -s tcpd"   
-          constraints:          
-            platform:
-            - ubuntu16
-          tests:  
-            test_items:
-            - flag: "install ok installed"
+        scored: true
+  - id: 3
+    description: "Network Configuration"
+  - id: 3.1
+    description: "Network Parameters (Host Only)etwork Parameters (Host Only)"
+    checks:
+      - id: 3.1.1.a
+        description: "Ensure IP forwarding is disabled"
+        audit: "sysctl net.ipv4.ip_forward"
+        tests:
+          test_items:
+            - flag: "net.ipv4.ip_forward"
+              compare:
+                op: eq
+                value: "0"
               set: true
-          remediation: |
-                Install TCP Wrappers using the appropriate package manager or manual installation:
-                
-                yum install tcp_wrappers
-                
-                
-                apt-get install tcpd
-                
-                
-                zypper install tcpd
-      - check:
-          audit: "apt-cache show tcpd"   
-          constraints:          
-            platform:
-            - ubuntu18
-          tests:  
-            test_items:
-            - flag: "Installed-Size:"
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.ip_forward = 0
+          net.ipv6.conf.all.forwarding = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.ip_forward=0
+          # sysctl -w net.ipv6.conf.all.forwarding=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.1.1.b
+        description: "Ensure IP forwarding is disabled"
+        audit: "grep ^\\s*\"net\\.ipv4\\.ip_forward\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.ip_forward"
+              compare:
+                op: eq
+                value: "0"
               set: true
-          remediation: |
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.ip_forward = 0
+          net.ipv6.conf.all.forwarding = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.ip_forward=0
+          # sysctl -w net.ipv6.conf.all.forwarding=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+      - id: 3.1.1.c
+        description: "Ensure IP forwarding is disabled"
+        audit: "sysctl net.ipv6.conf.all.forwarding"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.forwarding"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.ip_forward = 0
+          net.ipv6.conf.all.forwarding = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.ip_forward=0
+          # sysctl -w net.ipv6.conf.all.forwarding=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+      - id: 3.1.1.d
+        description: "Ensure IP forwarding is disabled"
+        audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.forwarding\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.forwarding"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.ip_forward = 0
+          net.ipv6.conf.all.forwarding = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.ip_forward=0
+          # sysctl -w net.ipv6.conf.all.forwarding=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+      - id: 3.1.2.a
+        description: "Ensure packet redirect sending is disabled"
+        audit: "sysctl net.ipv4.conf.all.send_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.send_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.send_redirects = 0
+          net.ipv4.conf.default.send_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.send_redirects=0
+          # sysctl -w net.ipv4.conf.default.send_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.1.2.b
+        description: "Ensure packet redirect sending is disabled"
+        audit: "sysctl net.ipv4.conf.default.send_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.send_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.send_redirects = 0
+          net.ipv4.conf.default.send_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.send_redirects=0
+          # sysctl -w net.ipv4.conf.default.send_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.1.2.c
+        description: "Ensure packet redirect sending is disabled"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.send_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.send_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.send_redirects = 0
+          net.ipv4.conf.default.send_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.send_redirects=0
+          # sysctl -w net.ipv4.conf.default.send_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.1.2.d
+        description: "Ensure packet redirect sending is disabled"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.send_redirects /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.send_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.send_redirects = 0
+          net.ipv4.conf.default.send_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.send_redirects=0
+          # sysctl -w net.ipv4.conf.default.send_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+  - id: 3.2
+    description: "Network Parameters (Host and Router)"
+    checks:
+      - id: 3.2.1.a
+        description: "Ensure source routed packets are not accepted"
+        audit: "sysctl net.ipv4.conf.all.accept_source_route"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.accept_source_route"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.1.b
+        description: "Ensure source routed packets are not accepted"
+        audit: "sysctl net.ipv4.conf.default.accept_source_route"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.accept_source_route"
+              compare:
+                op: eq
+                value: 0
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.1.c
+        description: "Ensure source routed packets are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.accept_source_route"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.1.d
+        description: "Ensure source routed packets are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.accept_source_route"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.1.e
+        description: "Ensure packet redirect sending is disabled"
+        audit: "sysctl net.ipv6.conf.all.accept_source_route"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.accept_source_route"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.1.f
+        description: "Ensure packet redirect sending is disabled"
+        audit: "sysctl net.ipv6.conf.default.accept_source_route"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.default.accept_source_route"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.1.g
+        description: "Ensure packet redirect sending is disabled"
+        audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.accept_source_route"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.1.h
+        description: "Ensure packet redirect sending is disabled"
+        audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.default\\.accept_source_route\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.default.accept_source_route"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_source_route = 0
+          net.ipv4.conf.default.accept_source_route = 0
+          net.ipv6.conf.all.accept_source_route = 0
+          net.ipv6.conf.default.accept_source_route = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_source_route=0
+          # sysctl -w net.ipv4.conf.default.accept_source_route=0
+          # sysctl -w net.ipv6.conf.all.accept_source_route=0
+          # sysctl -w net.ipv6.conf.default.accept_source_route=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.a
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "sysctl net.ipv4.conf.all.accept_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.b
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "sysctl net.ipv4.conf.default.accept_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.c
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.d
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.e
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "sysctl net.ipv6.conf.all.accept_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.f
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "sysctl net.ipv6.conf.default.accept_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.default.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.g
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.2.h
+        description: "Ensure ICMP redirects are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.default\\.accept_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.default.accept_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.accept_redirects = 0
+          net.ipv4.conf.default.accept_redirects = 0
+          net.ipv6.conf.all.accept_redirects = 0
+          net.ipv6.conf.default.accept_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.accept_redirects=0
+          # sysctl -w net.ipv4.conf.default.accept_redirects=0
+          # sysctl -w net.ipv6.conf.all.accept_redirects=0
+          # sysctl -w net.ipv6.conf.default.accept_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.3.a
+        description: "Ensure secure ICMP redirects are not accepted"
+        audit: "sysctl net.ipv4.conf.all.secure_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.secure_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.secure_redirects = 0
+          net.ipv4.conf.default.secure_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.secure_redirects=0
+          # sysctl -w net.ipv4.conf.default.secure_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.3.b
+        description: "Ensure secure ICMP redirects are not accepted"
+        audit: "sysctl net.ipv4.conf.default.secure_redirects"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.secure_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.secure_redirects = 0
+          net.ipv4.conf.default.secure_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.secure_redirects=0
+          # sysctl -w net.ipv4.conf.default.secure_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.3.c
+        description: "Ensure secure ICMP redirects are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.secure_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.secure_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.secure_redirects = 0
+          net.ipv4.conf.default.secure_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.secure_redirects=0
+          # sysctl -w net.ipv4.conf.default.secure_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.3.d
+        description: "Ensure secure ICMP redirects are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.secure_redirects\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.secure_redirects"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.secure_redirects = 0
+          net.ipv4.conf.default.secure_redirects = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.secure_redirects=0
+          # sysctl -w net.ipv4.conf.default.secure_redirects=0
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.4.a
+        description: "Ensure suspicious packets are logged"
+        audit: "sysctl net.ipv4.conf.all.log_martians"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.log_martians"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.log_martians = 1
+          net.ipv4.conf.default.log_martians = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.log_martians=1
+          # sysctl -w net.ipv4.conf.default.log_martians=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.4.b
+        description: "Ensure suspicious packets are logged"
+        audit: "sysctl net.ipv4.conf.default.log_martians"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.log_martians"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.log_martians = 1
+          net.ipv4.conf.default.log_martians = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.log_martians=1
+          # sysctl -w net.ipv4.conf.default.log_martians=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.4.c
+        description: "Ensure suspicious packets are logged"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.log_martians\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.log_martians"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.log_martians = 1
+          net.ipv4.conf.default.log_martians = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.log_martians=1
+          # sysctl -w net.ipv4.conf.default.log_martians=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.4.d
+        description: "Ensure suspicious packets are logged"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.log_martians\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.log_martians"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.log_martians = 1
+          net.ipv4.conf.default.log_martians = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.log_martians=1
+          # sysctl -w net.ipv4.conf.default.log_martians=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.5.a
+        description: "Ensure broadcast ICMP requests are ignored"
+        audit: "sysctl net.ipv4.icmp_echo_ignore_broadcasts"
+        tests:
+          test_items:
+            - flag: "net.ipv4.icmp_echo_ignore_broadcasts"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.5.b
+        description: "Ensure broadcast ICMP requests are ignored"
+        audit: "grep ^\\s*\"net\\.ipv4\\.icmp_echo_ignore_broadcasts\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.icmp_echo_ignore_broadcasts"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.6.a
+        description: "Ensure bogus ICMP responses are ignored"
+        audit: "sysctl net.ipv4.icmp_ignore_bogus_error_responses"
+        tests:
+          test_items:
+            - flag: "net.ipv4.icmp_ignore_bogus_error_responses"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.6.b
+        description: "Ensure bogus ICMP responses are ignored"
+        audit: "grep ^\\s*\"net\\.ipv4\\.icmp_ignore_bogus_error_responses\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.icmp_ignore_bogus_error_responses"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.7.a
+        description: "Ensure Reverse Path Filtering is enabled"
+        audit: "sysctl net.ipv4.conf.all.rp_filter"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.rp_filter"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.default.rp_filter = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.rp_filter=1
+          # sysctl -w net.ipv4.conf.default.rp_filter=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.7.b
+        description: "Ensure Reverse Path Filtering is enabled"
+        audit: "sysctl net.ipv4.conf.default.rp_filter"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.rp_filter"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.default.rp_filter = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.rp_filter=1
+          # sysctl -w net.ipv4.conf.default.rp_filter=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.7.c
+        description: "Ensure Reverse Path Filtering is enabled"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.all\\.rp_filter\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.all.rp_filter"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.default.rp_filter = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.rp_filter=1
+          # sysctl -w net.ipv4.conf.default.rp_filter=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.7.d
+        description: "Ensure Reverse Path Filtering is enabled"
+        audit: "grep ^\\s*\"net\\.ipv4\\.conf\\.default\\.rp_filter\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.conf.default.rp_filter"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.conf.all.rp_filter = 1
+          net.ipv4.conf.default.rp_filter = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.conf.all.rp_filter=1
+          # sysctl -w net.ipv4.conf.default.rp_filter=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.8.a
+        description: "Ensure TCP SYN Cookies is enabled"
+        audit: "sysctl net.ipv4.tcp_syncookies"
+        tests:
+          test_items:
+            - flag: "net.ipv4.tcp_syncookies"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.tcp_syncookies = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.tcp_syncookies=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.8.b
+        description: "Ensure TCP SYN Cookies is enabled"
+        audit: "grep ^\\s*\"net\\.ipv4\\.tcp_syncookies\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv4.tcp_syncookies"
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv4.tcp_syncookies = 1
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv4.tcp_syncookies=1
+          # sysctl -w net.ipv4.route.flush=1
+
+        scored: true
+
+      - id: 3.2.9.a
+        description: "Ensure IPv6 router advertisements are not accepted"
+        audit: "sysctl net.ipv6.conf.all.accept_ra"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.accept_ra"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv6.conf.all.accept_ra = 0
+          net.ipv6.conf.default.accept_ra = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv6.conf.all.accept_ra=0
+          # sysctl -w net.ipv6.conf.default.accept_ra=0
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.9.b
+        description: "Ensure IPv6 router advertisements are not accepted"
+        audit: "sysctl net.ipv6.conf.default.accept_ra"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.default.accept_ra"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv6.conf.all.accept_ra = 0
+          net.ipv6.conf.default.accept_ra = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv6.conf.all.accept_ra=0
+          # sysctl -w net.ipv6.conf.default.accept_ra=0
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.9.c
+        description: "Ensure IPv6 router advertisements are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.all\\.accept_ra\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.all.accept_ra"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv6.conf.all.accept_ra = 0
+          net.ipv6.conf.default.accept_ra = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv6.conf.all.accept_ra=0
+          # sysctl -w net.ipv6.conf.default.accept_ra=0
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+      - id: 3.2.9.d
+        description: "Ensure IPv6 router advertisements are not accepted"
+        audit: "grep ^\\s*\"net\\.ipv6\\.conf\\.default\\.accept_ra\" /etc/sysctl.conf /etc/sysctl.d/*"
+        tests:
+          test_items:
+            - flag: "net.ipv6.conf.default.accept_ra"
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/sysctl.conf` or a `/etc/sysctl.d/*` file:
+
+          net.ipv6.conf.all.accept_ra = 0
+          net.ipv6.conf.default.accept_ra = 0
+
+          Run the following commands to set the active kernel parameters:
+
+          # sysctl -w net.ipv6.conf.all.accept_ra=0
+          # sysctl -w net.ipv6.conf.default.accept_ra=0
+          # sysctl -w net.ipv6.route.flush=1
+
+        scored: true
+
+  - id: 3.3
+    description: "TCP Wrappers"
+    checks:
+      - id: 3.3.1
+        description: "Ensure TCP Wrappers is installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q tcp_wrappers"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: false
+              remediation: |
                 Install TCP Wrappers using the appropriate package manager or manual installation:
-                
+
                 yum install tcp_wrappers
-                
-                
+
+
                 apt-get install tcpd
-                
-                
+
+
                 zypper install tcpd
-      scored: false   
-    - id: 3.3.2
-      description: "Ensure /etc/hosts.allow is configured"
-      audit: "cat /etc/hosts.allow" 
-      type: manual
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Run the following command to create `/etc/hosts.allow` :
-            
-            # echo "ALL: /, /, ..." >/etc/hosts.allow
-            
-            where each `/` combination (for example, "192.168.1.0/255.255.255.0") represents one network block in use by your organization that requires access to this system.
-      scored: false                  
-                          
-            
-    - id: 3.3.3
-      description: "Ensure /etc/hosts.deny is configured"
-      audit: "cat /etc/hosts.deny"   
-      tests:
-        test_items:
-        - flag: "ALL: ALL"
-          set: true                        
-      remediation: |
-            Run the following command to create `/etc/hosts.deny` :
-            
-            # echo "ALL: ALL" >> /etc/hosts.deny
-            
-      scored: false                  
-            
+          - check:
+              audit: "dpkg -s tcpd"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
+                Install TCP Wrappers using the appropriate package manager or manual installation:
 
-    - id: 3.3.4
-      description: "Ensure permissions on /etc/hosts.allow are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/hosts.allow"   
-      tests:
-        test_items:
-        - flag: "644/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set permissions on `/etc/hosts.allow` :
-            
-            # chown root:root /etc/hosts.allow
-            # chmod 644 /etc/hosts.allow
-            
-      scored: true                  
-                       
-            
-    - id: 3.3.5
-      description: "Ensure permissions on /etc/hosts.deny are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/hosts.deny"   
-      tests:
-        test_items:
-        - flag: "644/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set permissions on `/etc/hosts.deny` :
-            
-            # chown root:root /etc/hosts.deny
-            # chmod 644 /etc/hosts.deny
-            
-      scored: true                  
-                        
-            
-- id: 3.4
-  description: "Uncommon Network Protocols"
-  checks:
-    - id: 3.4.1.a
-      description: "Ensure DCCP is disabled"
-      audit: "modprobe -n -v dccp"
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install dccp /bin/true
-            
-      scored: true                  
-            
-    - id: 3.4.1.b
-      description: "Ensure DCCP is disabled"
-      audit: "lsmod | grep dccp"
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install dccp /bin/true
-            
-      scored: true                  
-            
-    - id: 3.4.2.a
-      description: "Ensure SCTP is disabled"
-      audit: "modprobe -n -v sctp"   
+                yum install tcp_wrappers
 
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install sctp /bin/true
-            
-      scored: true                  
-            
-    - id: 3.4.2.b
-      description: "Ensure SCTP is disabled"
-      audit: "lsmod | grep sctp"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install sctp /bin/true
-            
-      scored: true                  
-            
-    - id: 3.4.3.a
-      description: "Ensure RDS is disabled"
-      audit: "modprobe -n -v rds"   
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          compare:
-            op: eq
-            value: "install /bin/true"
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install rds /bin/true
-            
-      scored: true                  
-            
-    - id: 3.4.3.b
-      description: "Ensure RDS is disabled"
-      audit: "lsmod | grep rds"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install rds /bin/true
-            
-      scored: true                  
-            
-    - id: 3.4.4.a
-      description: "Ensure TIPC is disabled"
-      audit: "modprobe -n -v tipc"   
-      tests:
-        test_items:
-        - flag: "install /bin/true"
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install tipc /bin/true
-            
-      scored: true                  
-            
-    - id: 3.4.4.b
-      description: "Ensure TIPC is disabled"
-      audit: "lsmod | grep tipc"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
-            
-            install tipc /bin/true
-            
-      scored: true                  
-            
-- id: 3.5
-  description: "Firewall Configuration"
-- id: 3.5.1
-  description: "Configure IPv6 ip6tables"
-  checks:
-    - id: 3.5.1.1
-      description: "Ensure IPv6 default deny firewall policy"
-      audit: "ip6tables -L"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Chain INPUT (policy DROP)"
-          set: true
-        - flag: "Chain FORWARD (policy DROP)"
-          set: true
-        - flag: "Chain OUTPUT (policy DROP)"
-          set: true                        
-      remediation: |
-            Run the following commands to implement a default DROP policy:
-                        
-            # iptables -P INPUT DROP
-            # iptables -P OUTPUT DROP
-            # iptables -P FORWARD DROP
-      scored: true
-      
-    - id: 3.5.1.2.a
-      description: "Ensure IPv6 loopback traffic is configured"
-      audit: "ip6tables -L INPUT -v -n" 
-      type: manual
-      tests:
-        test_items:
-        - 
-          flag: |
-            Chain INPUT (policy DROP 0 packets, 0 bytes)
-            pkts bytes target prot opt in out source destination
-            0 0 ACCEPT all -- lo * 0.0.0.0/0 0.0.0.0/0
-            0 0 DROP all -- * * 127.0.0.0/8 0.0.0.0/0
-          set: true                        
-      remediation: |
-            Run the following commands to implement the loopback rules:
-                        
-            # ip6tables -A INPUT -i lo -j ACCEPT 
-            # ip6tables -A OUTPUT -o lo -j ACCEPT 
-            # ip6tables -A INPUT -s ::1 -j DROP
-            
-      scored: true                  
-            
-    - id: 3.5.1.2.b
-      description: "Ensure IPv6 loopback traffic is configured"
-      audit: "ip6tables -L OUTPUT -v -n"  
-      type: manual
-      tests:
-        test_items:
-        -
-          flag: |
-            Chain OUTPUT (policy DROP 0 packets, 0 bytes)
-            pkts bytes target prot opt in out source destination
-            0 0 ACCEPT all -- * lo 0.0.0.0/0 0.0.0.0/0
-          set: true                        
-      remediation: |
-            Run the following commands to implement the loopback rules:
-                        
-            # ip6tables -A INPUT -i lo -j ACCEPT 
-            # ip6tables -A OUTPUT -o lo -j ACCEPT 
-            # ip6tables -A INPUT -s ::1 -j DROP
-            
-      scored: true 
-    - id: 3.5.1.3
-      description: "Ensure IPv6 outbound and established connections are configured"
-      audit: "ip6tables -L -v -n"   
-      type: manual     
-      remediation: |
-            Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections:
-                        
-            # ip6tables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT 
-            # ip6tables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT 
-            # ip6tables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT 
-            # ip6tables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT 
-            # ip6tables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT 
-            # ip6tables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
-            
-      scored: false 
-    - id: 3.5.1.4.a
-      description: "Ensure IPv6 firewall rules exist for all open ports"
-      audit: "ss -6tuln" 
-      type: manual                      
-      remediation: |
-            For each port identified in the audit which does not have a firewall rule establish a proper
-            rule for accepting inbound connections:
-                        
-            # ip6tables -A INPUT -p <protocol> --dport <port> -m state --state NEW -j ACCEPT
-            
-      scored: true                  
-            
-    - id: 3.5.1.4.b
-      description: "Ensure IPv6 firewall rules exist for all open ports"
-      audit: "ip6tables -L INPUT -v -n" 
-      type: manual                      
-      remediation: |
-            For each port identified in the audit which does not have a firewall rule establish a proper
-            rule for accepting inbound connections:
-                        
-            # ip6tables -A INPUT -p <protocol> --dport <port> -m state --state NEW -j ACCEPT
-            
-      scored: true 
 
-- id: 3.5.2
-  description: "Configure IPv4 iptables"
-  checks:      
-    - id: 3.5.2.1
-      description: "Ensure default deny firewall policy"
-      audit: "iptables -L"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Chain INPUT (policy DROP)"
-          set: true
-        - flag: "Chain FORWARD (policy DROP)"
-          set: true
-        - flag: "Chain OUTPUT (policy DROP)"
-          set: true                        
-      remediation: |
-            Run the following commands to implement a default DROP policy:
-                        
-            # iptables -P INPUT DROP
-            # iptables -P OUTPUT DROP
-            # iptables -P FORWARD DROP
-            
-      scored: true 
-    - id: 3.5.2.2.a
-      description: "Ensure loopback traffic is configured"
-      audit: "iptables -L INPUT -v -n" 
-      type: manual
-      tests:
-        test_items:
-        - 
-          flag: |
-            Chain INPUT (policy DROP 0 packets, 0 bytes)
-            pkts bytes target prot opt in out source destination
-            0 0 ACCEPT all -- lo * 0.0.0.0/0 0.0.0.0/0
-            0 0 DROP all -- * * 127.0.0.0/8 0.0.0.0/0
-          set: true                        
-      remediation: |
-            Run the following commands to implement the loopback rules:
-                        
-            # iptables -A INPUT -i lo -j ACCEPT
-            # iptables -A OUTPUT -o lo -j ACCEPT
-            # iptables -A INPUT -s 127.0.0.0/8 -j DROP
-            
-      scored: true                  
-            
-    - id: 3.5.2.2.b
-      description: "Ensure loopback traffic is configured"
-      audit: "iptables -L OUTPUT -v -n"  
-      type: manual
-      tests:
-        test_items:
-        -
-          flag: |
-            Chain OUTPUT (policy DROP 0 packets, 0 bytes)
-            pkts bytes target prot opt in out source destination
-            0 0 ACCEPT all -- * lo 0.0.0.0/0 0.0.0.0/0
-          set: true                        
-      remediation: |
-            Run the following commands to implement the loopback rules:
-                        
-            # iptables -A INPUT -i lo -j ACCEPT
-            # iptables -A OUTPUT -o lo -j ACCEPT
-            # iptables -A INPUT -s 127.0.0.0/8 -j DROP
-            
-      scored: true
-    - id: 3.5.2.3
-      description: "Ensure outbound and established connections are configured"
-      audit: "iptables -L -v -n"   
-      type: manual     
-      remediation: |
-            Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections:
-                        
-            # iptables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT
-            # iptables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT
-            # iptables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT
-            # iptables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
-            # iptables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT
-            # iptables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
-            
-      scored: false
-    - id: 3.5.2.4.a
-      description: "Ensure firewall rules exist for all open ports"
-      audit: "netstat -ln" 
-      type: manual
-      tests:
-        test_items:
-        - 
-          flag: |
-            Active Internet connections (only servers)
-            Proto Recv-Q Send-Q Local Address Foreign Address State
-            tcp 0 0 0.0.0.0:22 0.0.0.0:* LISTEN
-          set: true                        
-      remediation: |
-            For each port identified in the audit which does not have a firewall rule establish a proper rule for accepting inbound connections:
-                        
-            # iptables -A INPUT -p  --dport  -m state --state NEW -j ACCEPT
-            
-      scored: true                  
-            
-    - id: 3.5.2.4.b
-      description: "Ensure firewall rules exist for all open ports"
-      audit: "iptables -L INPUT -v -n" 
-      type: manual
-      tests:
-        test_items:
-        - 
-          flag: |
-            Chain INPUT (policy DROP 0 packets, 0 bytes)
-            pkts bytes target prot opt in out source destination
-            0 0 ACCEPT all -- lo * 0.0.0.0/0 0.0.0.0/0
-            0 0 DROP all -- * * 127.0.0.0/8 0.0.0.0/0
-            0 0 ACCEPT tcp -- * * 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 state NEW
+                apt-get install tcpd
 
-          set: true                        
-      remediation: |
-            For each port identified in the audit which does not have a firewall rule establish a proper rule for accepting inbound connections:
-                        
-            # iptables -A INPUT -p  --dport  -m state --state NEW -j ACCEPT
-            
-      scored: true
-    - id: 3.5.3
-      description: "Ensure iptables is installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q iptables"   
-          constraints:          
-            platform:
-            - rhel7
-          
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: false                       
-          remediation: |
-                Install `iptables` using the appropriate package manager or manual installation:
-                
-                # yum install iptables
-                
-                
-                # apt-get install iptables
-                
-                
-                # zypper install iptables
-      - check:
-          audit: "dpkg -s iptables"   
-          constraints:          
-            platform:
-            - ubuntu16
-          
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: true                       
-          remediation: |
-                Install `iptables` using the appropriate package manager or manual installation:
-                
-                # yum install iptables
-                
-                
-                # apt-get install iptables
-                
-                
-                # zypper install iptables
-      - check:
-          audit: "apt-cache show iptables"   
-          constraints:          
-            platform:
-            - ubuntu18
-          
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: true                       
-          remediation: |
-                Install `iptables` using the appropriate package manager or manual installation:
-                
-                # yum install iptables
-                
-                
-                # apt-get install iptables
-                
-                
-                # zypper install iptables
-      scored: true                  
 
-- id: 3.6
-  description: "Ensure wireless interfaces are disabled (Not Scored)"
-  checks:
-    - id: 3.6.a
-      description: "Ensure wireless interfaces are disabled"
-      audit: "iwconfig"
-      type: manual
-      remediation: |
-        Run the following command to disable any wireless interfaces:
+                zypper install tcpd
+          - check:
+              audit: "apt-cache show tcpd"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                Install TCP Wrappers using the appropriate package manager or manual installation:
 
-        # ip link set  down
+                yum install tcp_wrappers
 
-        Disable any wireless interfaces in your network configuration.
-      scored: false
 
-    - id: 3.6.b
-      description: "Ensure wireless interfaces are disabled"
-      audit: "ip link show up"
-      type: manual
-      remediation: |
-        Run the following command to disable any wireless interfaces:
+                apt-get install tcpd
 
-        # ip link set  down
 
-        Disable any wireless interfaces in your network configuration.
-      scored: false
-
-- id: 3.7
-  description: "Ensure wireless interfaces are disabled (Not Scored)"
-  checks:
-    - id: 3.7
-      description: "Disable IPv6"
-      sub_checks:
-      - check:
-          audit: "grep \"^\\s*linux\" /boot/grub/grub.cfg | grep -v ipv6.disabled=1"
-          constraints:
-            boot:
-            - grub
-          tests:
-            test_items:
+                zypper install tcpd
+        scored: false
+      - id: 3.3.2
+        description: "Ensure /etc/hosts.allow is configured"
+        audit: "cat /etc/hosts.allow"
+        type: manual
+        tests:
+          test_items:
             - flag: ""
               compare:
                 op: eq
                 value: ""
               set: true
-          remediation: |
-            Edit /etc/default/grub and add ipv6.disable=1 to the GRUB_CMDLINE_LINUX parameters:
-            GRUB_CMDLINE_LINUX="ipv6.disable=1"
-            Depending or your distribution, run the appropriate following command to update the grub2 configuration:
-            # grub2-mkconfig –o /boot/grub2/grub.cfg
-            or
-            # update-grub
-          
-      - check:
-          audit: "grep \"^\\s*linux\" /boot/grub2/grub.cfg | grep -v ipv6.disabled=1"
-          constraints:
-            boot:
-            - grub2
-          tests:
-            test_items:
+        remediation: |
+          Run the following command to create `/etc/hosts.allow` :
+
+          # echo "ALL: /, /, ..." >/etc/hosts.allow
+
+          where each `/` combination (for example, "192.168.1.0/255.255.255.0") represents one network block in use by your organization that requires access to this system.
+        scored: false
+
+      - id: 3.3.3
+        description: "Ensure /etc/hosts.deny is configured"
+        audit: "cat /etc/hosts.deny"
+        tests:
+          test_items:
+            - flag: "ALL: ALL"
+              set: true
+        remediation: |
+          Run the following command to create `/etc/hosts.deny` :
+
+          # echo "ALL: ALL" >> /etc/hosts.deny
+
+        scored: false
+
+      - id: 3.3.4
+        description: "Ensure permissions on /etc/hosts.allow are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/hosts.allow"
+        tests:
+          test_items:
+            - flag: "644/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set permissions on `/etc/hosts.allow` :
+
+          # chown root:root /etc/hosts.allow
+          # chmod 644 /etc/hosts.allow
+
+        scored: true
+
+      - id: 3.3.5
+        description: "Ensure permissions on /etc/hosts.deny are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/hosts.deny"
+        tests:
+          test_items:
+            - flag: "644/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set permissions on `/etc/hosts.deny` :
+
+          # chown root:root /etc/hosts.deny
+          # chmod 644 /etc/hosts.deny
+
+        scored: true
+
+  - id: 3.4
+    description: "Uncommon Network Protocols"
+    checks:
+      - id: 3.4.1.a
+        description: "Ensure DCCP is disabled"
+        audit: "modprobe -n -v dccp"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install dccp /bin/true
+
+        scored: true
+
+      - id: 3.4.1.b
+        description: "Ensure DCCP is disabled"
+        audit: "lsmod | grep dccp"
+        tests:
+          test_items:
             - flag: ""
               compare:
                 op: eq
                 value: ""
               set: true
-          remediation: |
-            Edit /etc/default/grub and add ipv6.disable=1 to the GRUB_CMDLINE_LINUX parameters:
-            GRUB_CMDLINE_LINUX="ipv6.disable=1"
-            Depending or your distribution, run the appropriate following command to update the grub2 configuration:
-            # grub2-mkconfig –o /boot/grub2/grub.cfg
-            or
-            # update-grub
-      scored: false
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install dccp /bin/true
+
+        scored: true
+
+      - id: 3.4.2.a
+        description: "Ensure SCTP is disabled"
+        audit: "modprobe -n -v sctp"
+
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install sctp /bin/true
+
+        scored: true
+
+      - id: 3.4.2.b
+        description: "Ensure SCTP is disabled"
+        audit: "lsmod | grep sctp"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install sctp /bin/true
+
+        scored: true
+
+      - id: 3.4.3.a
+        description: "Ensure RDS is disabled"
+        audit: "modprobe -n -v rds"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              compare:
+                op: eq
+                value: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install rds /bin/true
+
+        scored: true
+
+      - id: 3.4.3.b
+        description: "Ensure RDS is disabled"
+        audit: "lsmod | grep rds"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install rds /bin/true
+
+        scored: true
+
+      - id: 3.4.4.a
+        description: "Ensure TIPC is disabled"
+        audit: "modprobe -n -v tipc"
+        tests:
+          test_items:
+            - flag: "install /bin/true"
+              set: true
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install tipc /bin/true
+
+        scored: true
+
+      - id: 3.4.4.b
+        description: "Ensure TIPC is disabled"
+        audit: "lsmod | grep tipc"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Edit or create the file `/etc/modprobe.d/CIS.conf` and add the following line:
+
+          install tipc /bin/true
+
+        scored: true
+
+  - id: 3.5
+    description: "Firewall Configuration"
+  - id: 3.5.1
+    description: "Configure IPv6 ip6tables"
+    checks:
+      - id: 3.5.1.1
+        description: "Ensure IPv6 default deny firewall policy"
+        audit: "ip6tables -L"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Chain INPUT (policy DROP)"
+              set: true
+            - flag: "Chain FORWARD (policy DROP)"
+              set: true
+            - flag: "Chain OUTPUT (policy DROP)"
+              set: true
+        remediation: |
+          Run the following commands to implement a default DROP policy:
+
+          # iptables -P INPUT DROP
+          # iptables -P OUTPUT DROP
+          # iptables -P FORWARD DROP
+        scored: true
+
+      - id: 3.5.1.2.a
+        description: "Ensure IPv6 loopback traffic is configured"
+        audit: "ip6tables -L INPUT -v -n"
+        type: manual
+        tests:
+          test_items:
+            - flag: |
+                Chain INPUT (policy DROP 0 packets, 0 bytes)
+                pkts bytes target prot opt in out source destination
+                0 0 ACCEPT all -- lo * 0.0.0.0/0 0.0.0.0/0
+                0 0 DROP all -- * * 127.0.0.0/8 0.0.0.0/0
+              set: true
+        remediation: |
+          Run the following commands to implement the loopback rules:
+
+          # ip6tables -A INPUT -i lo -j ACCEPT
+          # ip6tables -A OUTPUT -o lo -j ACCEPT
+          # ip6tables -A INPUT -s ::1 -j DROP
+
+        scored: true
+
+      - id: 3.5.1.2.b
+        description: "Ensure IPv6 loopback traffic is configured"
+        audit: "ip6tables -L OUTPUT -v -n"
+        type: manual
+        tests:
+          test_items:
+            - flag: |
+                Chain OUTPUT (policy DROP 0 packets, 0 bytes)
+                pkts bytes target prot opt in out source destination
+                0 0 ACCEPT all -- * lo 0.0.0.0/0 0.0.0.0/0
+              set: true
+        remediation: |
+          Run the following commands to implement the loopback rules:
+
+          # ip6tables -A INPUT -i lo -j ACCEPT
+          # ip6tables -A OUTPUT -o lo -j ACCEPT
+          # ip6tables -A INPUT -s ::1 -j DROP
+
+        scored: true
+      - id: 3.5.1.3
+        description: "Ensure IPv6 outbound and established connections are configured"
+        audit: "ip6tables -L -v -n"
+        type: manual
+        remediation: |
+          Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections:
+
+          # ip6tables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT
+          # ip6tables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT
+          # ip6tables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT
+          # ip6tables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
+          # ip6tables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT
+          # ip6tables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
+
+        scored: false
+      - id: 3.5.1.4.a
+        description: "Ensure IPv6 firewall rules exist for all open ports"
+        audit: "ss -6tuln"
+        type: manual
+        remediation: |
+          For each port identified in the audit which does not have a firewall rule establish a proper
+          rule for accepting inbound connections:
+
+          # ip6tables -A INPUT -p <protocol> --dport <port> -m state --state NEW -j ACCEPT
+
+        scored: true
+
+      - id: 3.5.1.4.b
+        description: "Ensure IPv6 firewall rules exist for all open ports"
+        audit: "ip6tables -L INPUT -v -n"
+        type: manual
+        remediation: |
+          For each port identified in the audit which does not have a firewall rule establish a proper
+          rule for accepting inbound connections:
+
+          # ip6tables -A INPUT -p <protocol> --dport <port> -m state --state NEW -j ACCEPT
+
+        scored: true
+
+  - id: 3.5.2
+    description: "Configure IPv4 iptables"
+    checks:
+      - id: 3.5.2.1
+        description: "Ensure default deny firewall policy"
+        audit: "iptables -L"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Chain INPUT (policy DROP)"
+              set: true
+            - flag: "Chain FORWARD (policy DROP)"
+              set: true
+            - flag: "Chain OUTPUT (policy DROP)"
+              set: true
+        remediation: |
+          Run the following commands to implement a default DROP policy:
+
+          # iptables -P INPUT DROP
+          # iptables -P OUTPUT DROP
+          # iptables -P FORWARD DROP
+
+        scored: true
+      - id: 3.5.2.2.a
+        description: "Ensure loopback traffic is configured"
+        audit: "iptables -L INPUT -v -n"
+        type: manual
+        tests:
+          test_items:
+            - flag: |
+                Chain INPUT (policy DROP 0 packets, 0 bytes)
+                pkts bytes target prot opt in out source destination
+                0 0 ACCEPT all -- lo * 0.0.0.0/0 0.0.0.0/0
+                0 0 DROP all -- * * 127.0.0.0/8 0.0.0.0/0
+              set: true
+        remediation: |
+          Run the following commands to implement the loopback rules:
+
+          # iptables -A INPUT -i lo -j ACCEPT
+          # iptables -A OUTPUT -o lo -j ACCEPT
+          # iptables -A INPUT -s 127.0.0.0/8 -j DROP
+
+        scored: true
+
+      - id: 3.5.2.2.b
+        description: "Ensure loopback traffic is configured"
+        audit: "iptables -L OUTPUT -v -n"
+        type: manual
+        tests:
+          test_items:
+            - flag: |
+                Chain OUTPUT (policy DROP 0 packets, 0 bytes)
+                pkts bytes target prot opt in out source destination
+                0 0 ACCEPT all -- * lo 0.0.0.0/0 0.0.0.0/0
+              set: true
+        remediation: |
+          Run the following commands to implement the loopback rules:
+
+          # iptables -A INPUT -i lo -j ACCEPT
+          # iptables -A OUTPUT -o lo -j ACCEPT
+          # iptables -A INPUT -s 127.0.0.0/8 -j DROP
+
+        scored: true
+      - id: 3.5.2.3
+        description: "Ensure outbound and established connections are configured"
+        audit: "iptables -L -v -n"
+        type: manual
+        remediation: |
+          Configure iptables in accordance with site policy. The following commands will implement a policy to allow all outbound connections and all established connections:
+
+          # iptables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT
+          # iptables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT
+          # iptables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT
+          # iptables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
+          # iptables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT
+          # iptables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
+
+        scored: false
+      - id: 3.5.2.4.a
+        description: "Ensure firewall rules exist for all open ports"
+        audit: "netstat -ln"
+        type: manual
+        tests:
+          test_items:
+            - flag: |
+                Active Internet connections (only servers)
+                Proto Recv-Q Send-Q Local Address Foreign Address State
+                tcp 0 0 0.0.0.0:22 0.0.0.0:* LISTEN
+              set: true
+        remediation: |
+          For each port identified in the audit which does not have a firewall rule establish a proper rule for accepting inbound connections:
+
+          # iptables -A INPUT -p  --dport  -m state --state NEW -j ACCEPT
+
+        scored: true
+
+      - id: 3.5.2.4.b
+        description: "Ensure firewall rules exist for all open ports"
+        audit: "iptables -L INPUT -v -n"
+        type: manual
+        tests:
+          test_items:
+            - flag: |
+                Chain INPUT (policy DROP 0 packets, 0 bytes)
+                pkts bytes target prot opt in out source destination
+                0 0 ACCEPT all -- lo * 0.0.0.0/0 0.0.0.0/0
+                0 0 DROP all -- * * 127.0.0.0/8 0.0.0.0/0
+                0 0 ACCEPT tcp -- * * 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 state NEW
+
+              set: true
+        remediation: |
+          For each port identified in the audit which does not have a firewall rule establish a proper rule for accepting inbound connections:
+
+          # iptables -A INPUT -p  --dport  -m state --state NEW -j ACCEPT
+
+        scored: true
+      - id: 3.5.3
+        description: "Ensure iptables is installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q iptables"
+              constraints:
+                platform:
+                  - rhel7
+
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: false
+              remediation: |
+                Install `iptables` using the appropriate package manager or manual installation:
+
+                # yum install iptables
 
 
-- id: 4
-  description: "Logging and Auditing"
-- id: 4.1
-  description: "Configure System Accounting (auditd)"
-  checks:
-- id: 4.1.1
-  description: "Configure Data Retention"
-  checks:
-    - id: 4.1.1.1
-      description: "Ensure audit log storage size is configured"
-      audit: "grep max_log_file /etc/audit/auditd.conf"   
-      type: "manual"
-      tests:
-        test_items:
-        - flag: "max_log_file"
-          compare:
-            op: has
-            value: "<MB>"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/audit/auditd.conf` in accordance with site policy:
-            
-            max_log_file = 
-            
-      scored: true                  
-            
-    - id: 4.1.1.2.a
-      description: "Ensure system is disabled when audit logs are full"
-      audit: "grep ^space_left_action /etc/audit/auditd.conf"   
-      tests:
-        test_items:
-        - flag: "space_left_action = email"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/audit/auditd.conf:` 
-            
-            space_left_action = email
-            action_mail_acct = root
-            admin_space_left_action = halt
-            
-      scored: true                  
-            
-    - id: 4.1.1.2.b
-      description: "Ensure system is disabled when audit logs are full"
-      audit: "grep action_mail_acct /etc/audit/auditd.conf"   
-      tests:
-        test_items:
-        - flag: "action_mail_acct = root"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/audit/auditd.conf:` 
-            
-            space_left_action = email
-            action_mail_acct = root
-            admin_space_left_action = halt
-            
-      scored: true                  
-            
-    - id: 4.1.1.2.c
-      description: "Ensure system is disabled when audit logs are full"
-      audit: "grep admin_space_left_action /etc/audit/auditd.conf"   
-      tests:
-        test_items:
-        - flag: "admin_space_left_action = halt"
-          set: true                        
-      remediation: |
-            Set the following parameters in `/etc/audit/auditd.conf:` 
-            
-            space_left_action = email
-            action_mail_acct = root
-            admin_space_left_action = halt
-            
-      scored: true                  
-            
-    - id: 4.1.1.3
-      description: "Ensure audit logs are not automatically deleted"
-      audit: "grep max_log_file_action /etc/audit/auditd.conf"   
-      tests:
-        test_items:
-        - flag: "max_log_file_action = keep_logs"
-          set: true                        
-      remediation: |
-            Set the following parameter in `/etc/audit/auditd.conf:` 
-            
-            max_log_file_action = keep_logs
-            
-      scored: true                              
-    - id: 4.1.2
-      description: "Ensure auditd service is enabled"
-      sub_checks:
-      - check:
-          audit: "rpm -q audit audit-libs"   
-          constraints:
-            platform: 
-            - rhel7
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: false                        
-          remediation: |
-                Run the following command to Install auditd 
-                # yum install audit audit-libs 
-                # apt-get install auditd audispd-plugins 
-                # zipper install audit audit-libs 
-      - check:
-          audit: "dpkg -s auditd audispd-plugins"   
-          constraints:
-            platform: 
-            - ubuntu16
-          tests:
-            test_items:
-            - flag: "install ok installed"
-              set: true                        
-          remediation: |
-                Run the following command to Install auditd 
-                # yum install audit audit-libs 
-                # apt-get install auditd audispd-plugins 
-                # zipper install audit audit-libs 
-      - check:
-          audit: "apt-cache show auditd" 
-          constraints:
-            platform: 
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
-              set: true                        
-          remediation: |
-                Run the following command to Install auditd 
-                # yum install audit audit-libs 
-                # apt-get install auditd audispd-plugins 
-                # zipper install audit audit-libs 
-      scored: true
-    - id: 4.1.3
-      description: "Ensure auditd service is enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list auditd"   
-          constraints:
-            platform: 
-            - rhel6
-          tests:
-            test_items:
-            - flag: "auditd 0:off 1:off 2:on 3:on 4:on 5:on 6:off"
-              set: true                        
-          remediation: |
+                # apt-get install iptables
+
+
+                # zypper install iptables
+          - check:
+              audit: "dpkg -s iptables"
+              constraints:
+                platform:
+                  - ubuntu16
+
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
+                Install `iptables` using the appropriate package manager or manual installation:
+
+                # yum install iptables
+
+
+                # apt-get install iptables
+
+
+                # zypper install iptables
+          - check:
+              audit: "apt-cache show iptables"
+              constraints:
+                platform:
+                  - ubuntu18
+
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                Install `iptables` using the appropriate package manager or manual installation:
+
+                # yum install iptables
+
+
+                # apt-get install iptables
+
+
+                # zypper install iptables
+        scored: true
+
+  - id: 3.6
+    description: "Ensure wireless interfaces are disabled (Not Scored)"
+    checks:
+      - id: 3.6.a
+        description: "Ensure wireless interfaces are disabled"
+        audit: "iwconfig"
+        type: manual
+        remediation: |
+          Run the following command to disable any wireless interfaces:
+
+          # ip link set  down
+
+          Disable any wireless interfaces in your network configuration.
+        scored: false
+
+      - id: 3.6.b
+        description: "Ensure wireless interfaces are disabled"
+        audit: "ip link show up"
+        type: manual
+        remediation: |
+          Run the following command to disable any wireless interfaces:
+
+          # ip link set  down
+
+          Disable any wireless interfaces in your network configuration.
+        scored: false
+
+  - id: 3.7
+    description: "Ensure wireless interfaces are disabled (Not Scored)"
+    checks:
+      - id: 3.7
+        description: "Disable IPv6"
+        sub_checks:
+          - check:
+              audit: "grep \"^\\s*linux\" /boot/grub/grub.cfg | grep -v ipv6.disabled=1"
+              constraints:
+                boot:
+                  - grub
+              tests:
+                test_items:
+                  - flag: ""
+                    compare:
+                      op: eq
+                      value: ""
+                    set: true
+              remediation: |
+                Edit /etc/default/grub and add ipv6.disable=1 to the GRUB_CMDLINE_LINUX parameters:
+                GRUB_CMDLINE_LINUX="ipv6.disable=1"
+                Depending or your distribution, run the appropriate following command to update the grub2 configuration:
+                # grub2-mkconfig –o /boot/grub2/grub.cfg
+                or
+                # update-grub
+
+          - check:
+              audit: "grep \"^\\s*linux\" /boot/grub2/grub.cfg | grep -v ipv6.disabled=1"
+              constraints:
+                boot:
+                  - grub2
+              tests:
+                test_items:
+                  - flag: ""
+                    compare:
+                      op: eq
+                      value: ""
+                    set: true
+              remediation: |
+                Edit /etc/default/grub and add ipv6.disable=1 to the GRUB_CMDLINE_LINUX parameters:
+                GRUB_CMDLINE_LINUX="ipv6.disable=1"
+                Depending or your distribution, run the appropriate following command to update the grub2 configuration:
+                # grub2-mkconfig –o /boot/grub2/grub.cfg
+                or
+                # update-grub
+        scored: false
+
+  - id: 4
+    description: "Logging and Auditing"
+  - id: 4.1
+    description: "Configure System Accounting (auditd)"
+    checks:
+  - id: 4.1.1
+    description: "Configure Data Retention"
+    checks:
+      - id: 4.1.1.1
+        description: "Ensure audit log storage size is configured"
+        audit: "grep max_log_file /etc/audit/auditd.conf"
+        type: "manual"
+        tests:
+          test_items:
+            - flag: "max_log_file"
+              compare:
+                op: has
+                value: "<MB>"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/audit/auditd.conf` in accordance with site policy:
+
+          max_log_file =
+
+        scored: true
+
+      - id: 4.1.1.2.a
+        description: "Ensure system is disabled when audit logs are full"
+        audit: "grep ^space_left_action /etc/audit/auditd.conf"
+        tests:
+          test_items:
+            - flag: "space_left_action = email"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/audit/auditd.conf:`
+
+          space_left_action = email
+          action_mail_acct = root
+          admin_space_left_action = halt
+
+        scored: true
+
+      - id: 4.1.1.2.b
+        description: "Ensure system is disabled when audit logs are full"
+        audit: "grep action_mail_acct /etc/audit/auditd.conf"
+        tests:
+          test_items:
+            - flag: "action_mail_acct = root"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/audit/auditd.conf:`
+
+          space_left_action = email
+          action_mail_acct = root
+          admin_space_left_action = halt
+
+        scored: true
+
+      - id: 4.1.1.2.c
+        description: "Ensure system is disabled when audit logs are full"
+        audit: "grep admin_space_left_action /etc/audit/auditd.conf"
+        tests:
+          test_items:
+            - flag: "admin_space_left_action = halt"
+              set: true
+        remediation: |
+          Set the following parameters in `/etc/audit/auditd.conf:`
+
+          space_left_action = email
+          action_mail_acct = root
+          admin_space_left_action = halt
+
+        scored: true
+
+      - id: 4.1.1.3
+        description: "Ensure audit logs are not automatically deleted"
+        audit: "grep max_log_file_action /etc/audit/auditd.conf"
+        tests:
+          test_items:
+            - flag: "max_log_file_action = keep_logs"
+              set: true
+        remediation: |
+          Set the following parameter in `/etc/audit/auditd.conf:`
+
+          max_log_file_action = keep_logs
+
+        scored: true
+      - id: 4.1.2
+        description: "Ensure auditd service is enabled"
+        sub_checks:
+          - check:
+              audit: "rpm -q audit audit-libs"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: false
+              remediation: |
+                Run the following command to Install auditd
+                # yum install audit audit-libs
+                # apt-get install auditd audispd-plugins
+                # zipper install audit audit-libs
+          - check:
+              audit: "dpkg -s auditd audispd-plugins"
+              constraints:
+                platform:
+                  - ubuntu16
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
+                Run the following command to Install auditd
+                # yum install audit audit-libs
+                # apt-get install auditd audispd-plugins
+                # zipper install audit audit-libs
+          - check:
+              audit: "apt-cache show auditd"
+              constraints:
+                platform:
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                Run the following command to Install auditd
+                # yum install audit audit-libs
+                # apt-get install auditd audispd-plugins
+                # zipper install audit audit-libs
+        scored: true
+      - id: 4.1.3
+        description: "Ensure auditd service is enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list auditd"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "auditd 0:off 1:off 2:on 3:on 4:on 5:on 6:off"
+                    set: true
+              remediation: |
                 Run one of the following commands to enable `auditd` :
-                
+
                 # chkconfig auditd on
-                
-                
+
+
                 # systemctl enable auditd
-                
-                
-                # update-rc.d auditd enable   
-      - check:
-          audit: "systemctl is-enabled auditd"   
-          constraints:
-            platform: 
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: true                        
-          remediation: |
-                Run one of the following commands to enable `auditd` :
-                
-                # chkconfig auditd on
-                
-                
-                # systemctl enable auditd
-                
-                
+
+
                 # update-rc.d auditd enable
-      - check:
-          audit: "ls /etc/rc*.d | grep auditd" 
-          type: manual
-          constraints:
-            platform: 
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: ""
-              compare:
-                op: eq
-                value: ""
-              set: true                        
-          remediation: |
+          - check:
+              audit: "systemctl is-enabled auditd"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: true
+              remediation: |
                 Run one of the following commands to enable `auditd` :
-                
+
                 # chkconfig auditd on
-                
-                
+
+
                 # systemctl enable auditd
-                
-                
+
+
                 # update-rc.d auditd enable
-      scored: true
-    - id: 4.1.4
-      description: "Ensure auditing for processes that start prior to auditd is enabled"
-      sub_checks:
-      - check:
-          audit: "grep \"^\\s*kernel\" /boot/grub/menu.lst"   
-          constraints:
-            boot:
-            - grub
-          tests:
-            test_items:
-            - flag: "audit=1"
-              set: true
-            remediation: |
+          - check:
+              audit: "ls /etc/rc*.d | grep auditd"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: ""
+                    compare:
+                      op: eq
+                      value: ""
+                    set: true
+              remediation: |
+                Run one of the following commands to enable `auditd` :
+
+                # chkconfig auditd on
+
+
+                # systemctl enable auditd
+
+
+                # update-rc.d auditd enable
+        scored: true
+      - id: 4.1.4
+        description: "Ensure auditing for processes that start prior to auditd is enabled"
+        sub_checks:
+          - check:
+              audit: "grep \"^\\s*kernel\" /boot/grub/menu.lst"
+              constraints:
+                boot:
+                  - grub
+              tests:
+                test_items:
+                  - flag: "audit=1"
+                    set: true
+                remediation: |
                   For `grub` based systems edit `/boot/grub/menu.lst` to include `audit=1` on all `kernel` lines.
                   For `grub2` based systems edit /etc/default/grub and add audit=1 to GRUB\_CMDLINE\_LINUX:
-                  
+
                   GRUB_CMDLINE_LINUX="audit=1"
-                  
+
                   Run the following command to update the `grub2` configuration:
-                  
+
                   # update-grub
-      - check:
-          audit: "grep -i linux /etc/default/grub"   
-          constraints:
-            boot:
-            - grub2
-          bin_op: and
-          tests:
-            test_items:
-            - flag: "GRUB_CMDLINE_LINUX="
-              set: true
-            - flag: "audit=1"
-              set: true
-          remediation: |
+          - check:
+              audit: "grep -i linux /etc/default/grub"
+              constraints:
+                boot:
+                  - grub2
+              bin_op: and
+              tests:
+                test_items:
+                  - flag: "GRUB_CMDLINE_LINUX="
+                    set: true
+                  - flag: "audit=1"
+                    set: true
+              remediation: |
                 For `grub` based systems edit `/boot/grub/menu.lst` to include `audit=1` on all `kernel` lines.
                 For `grub2` based systems edit /etc/default/grub and add audit=1 to GRUB\_CMDLINE\_LINUX:
-                
+
                 GRUB_CMDLINE_LINUX="audit=1"
-                
+
                 Run the following command to update the `grub2` configuration:
-                
+
                 # update-grub
-      scored: true
-    - id: 4.1.5.a
-      description: "Ensure events that modify date and time information are collected"
-      audit: "grep time-change /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S clock_settime -k time-change"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S clock_settime -k time-change"
-          set: true
-        - flag: "-w /etc/localtime -p wa -k time-change"
-          set: true
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
-            -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
-            -a always,exit -F arch=b64 -S clock_settime -k time-change
-            -a always,exit -F arch=b32 -S clock_settime -k time-change
-            -w /etc/localtime -p wa -k time-change
-            
-      scored: true 
-      
-    - id: 4.1.5.b
-      description: "Ensure events that modify date and time information are collected"
-      audit: "auditctl -l | grep time-change"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=time-change"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S stime,settimeofday,adjtimex -F key=time-change"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S clock_settime -F key=time-change"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S clock_settime -F key=time-change"
-          set: true
-        - flag: "-w /etc/localtime -p wa -k time-change"
-          set: true                    
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
-            -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
-            -a always,exit -F arch=b64 -S clock_settime -k time-change
-            -a always,exit -F arch=b32 -S clock_settime -k time-change
-            -w /etc/localtime -p wa -k time-change
-            
-      scored: true
-    - id: 4.1.6.a
-      description: "Ensure events that modify user/group information are collected"
-      audit: "grep identity /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-w /etc/group -p wa -k identity"
-          set: true  
-        - flag: "-w /etc/passwd -p wa -k identity"
-          set: true
-        - flag: "-w /etc/gshadow -p wa -k identity"
-          set: true
-        - flag: "-w /etc/shadow -p wa -k identity"
-          set: true
-        - flag: "-w /etc/security/opasswd -p wa -k identity"
-          set: true                        
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /etc/group -p wa -k identity
-            -w /etc/passwd -p wa -k identity
-            -w /etc/gshadow -p wa -k identity
-            -w /etc/shadow -p wa -k identity
-            -w /etc/security/opasswd -p wa -k identity
-            
-      scored: true                  
-            
-    - id: 4.1.6.b
-      description: "Ensure events that modify user/group information are collected"
-      audit: "auditctl -l | grep identity"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-w /etc/group -p wa -k identity"
-          set: true  
-        - flag: "-w /etc/passwd -p wa -k identity"
-          set: true
-        - flag: "-w /etc/gshadow -p wa -k identity"
-          set: true
-        - flag: "-w /etc/shadow -p wa -k identity"
-          set: true
-        - flag: "-w /etc/security/opasswd -p wa -k identity"
-          set: true                        
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /etc/group -p wa -k identity
-            -w /etc/passwd -p wa -k identity
-            -w /etc/gshadow -p wa -k identity
-            -w /etc/shadow -p wa -k identity
-            -w /etc/security/opasswd -p wa -k identity
-            
-      scored: true                  
-            
-    - id: 4.1.7.a
-      description: "Ensure events that modify the system's network environment are collected"
-      audit: "grep system-locale /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale"
-          set: true
-        - flag: "-w /etc/issue -p wa -k system-locale"
-          set: true
-        - flag: "-w /etc/issue.net -p wa -k system-locale"
-          set: true
-        - flag: "-w /etc/hosts -p wa -k system-locale"
-          set: true
-        - flag: "-w /etc/sysconfig/network -p wa -k system-locale"
-          set: true
-      remediation: |    
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
-            -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
-            -w /etc/issue -p wa -k system-locale
-            -w /etc/issue.net -p wa -k system-locale
-            -w /etc/hosts -p wa -k system-locale
-            -w /etc/sysconfig/network -p wa -k system-locale               
-      scored: true
-    - id: 4.1.7.b
-      description: "Ensure events that modify the system's network environment are collected"
-      audit: "auditctl -l | grep system-locale"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale"
-          set: true
-        - flag: "-w /etc/issue -p wa -k system-locale"
-          set: true
-        - flag: "-w /etc/issue.net -p wa -k system-locale"
-          set: true
-        - flag: "-w /etc/hosts -p wa -k system-locale"
-          set: true
-        - flag: "-w /etc/sysconfig/network -p wa -k system-locale"
-          set: true
-      remediation: | 
-              For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-              Example: vi /etc/audit/rules.d/audit.rules 
-              and add the following lines:
-              -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
-              -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
-              -w /etc/issue -p wa -k system-locale
-              -w /etc/issue.net -p wa -k system-locale
-              -w /etc/hosts -p wa -k system-locale
-              -w /etc/sysconfig/network -p wa -k system-locale               
-      scored: true                  
-    - id: 4.1.8.a
-      description: "Ensure events that modify the system's Mandatory Access Controls are collected"
-      sub_checks:
-      - check:
-          audit: "grep MAC-policy /etc/audit/rules.d/*.rules"   
-          constraints: 
-            lsm:
-            - selinux
-          tests:
-            bin_op: and
-            test_items:
-            - flag: "-w /etc/selinux/ -p wa -k MAC-policy"
+        scored: true
+      - id: 4.1.5.a
+        description: "Ensure events that modify date and time information are collected"
+        audit: "grep time-change /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change"
               set: true
-            - flag: "-w /usr/share/selinux/ -p wa -k MAC-policy"
-              set: true                       
-          remediation: |
+            - flag: "-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S clock_settime -k time-change"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S clock_settime -k time-change"
+              set: true
+            - flag: "-w /etc/localtime -p wa -k time-change"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
+          -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
+          -a always,exit -F arch=b64 -S clock_settime -k time-change
+          -a always,exit -F arch=b32 -S clock_settime -k time-change
+          -w /etc/localtime -p wa -k time-change
+
+        scored: true
+
+      - id: 4.1.5.b
+        description: "Ensure events that modify date and time information are collected"
+        audit: "auditctl -l | grep time-change"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=time-change"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S stime,settimeofday,adjtimex -F key=time-change"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S clock_settime -F key=time-change"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S clock_settime -F key=time-change"
+              set: true
+            - flag: "-w /etc/localtime -p wa -k time-change"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
+          -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
+          -a always,exit -F arch=b64 -S clock_settime -k time-change
+          -a always,exit -F arch=b32 -S clock_settime -k time-change
+          -w /etc/localtime -p wa -k time-change
+
+        scored: true
+      - id: 4.1.6.a
+        description: "Ensure events that modify user/group information are collected"
+        audit: "grep identity /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-w /etc/group -p wa -k identity"
+              set: true
+            - flag: "-w /etc/passwd -p wa -k identity"
+              set: true
+            - flag: "-w /etc/gshadow -p wa -k identity"
+              set: true
+            - flag: "-w /etc/shadow -p wa -k identity"
+              set: true
+            - flag: "-w /etc/security/opasswd -p wa -k identity"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /etc/group -p wa -k identity
+          -w /etc/passwd -p wa -k identity
+          -w /etc/gshadow -p wa -k identity
+          -w /etc/shadow -p wa -k identity
+          -w /etc/security/opasswd -p wa -k identity
+
+        scored: true
+
+      - id: 4.1.6.b
+        description: "Ensure events that modify user/group information are collected"
+        audit: "auditctl -l | grep identity"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-w /etc/group -p wa -k identity"
+              set: true
+            - flag: "-w /etc/passwd -p wa -k identity"
+              set: true
+            - flag: "-w /etc/gshadow -p wa -k identity"
+              set: true
+            - flag: "-w /etc/shadow -p wa -k identity"
+              set: true
+            - flag: "-w /etc/security/opasswd -p wa -k identity"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /etc/group -p wa -k identity
+          -w /etc/passwd -p wa -k identity
+          -w /etc/gshadow -p wa -k identity
+          -w /etc/shadow -p wa -k identity
+          -w /etc/security/opasswd -p wa -k identity
+
+        scored: true
+
+      - id: 4.1.7.a
+        description: "Ensure events that modify the system's network environment are collected"
+        audit: "grep system-locale /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale"
+              set: true
+            - flag: "-w /etc/issue -p wa -k system-locale"
+              set: true
+            - flag: "-w /etc/issue.net -p wa -k system-locale"
+              set: true
+            - flag: "-w /etc/hosts -p wa -k system-locale"
+              set: true
+            - flag: "-w /etc/sysconfig/network -p wa -k system-locale"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
+          -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
+          -w /etc/issue -p wa -k system-locale
+          -w /etc/issue.net -p wa -k system-locale
+          -w /etc/hosts -p wa -k system-locale
+          -w /etc/sysconfig/network -p wa -k system-locale
+        scored: true
+      - id: 4.1.7.b
+        description: "Ensure events that modify the system's network environment are collected"
+        audit: "auditctl -l | grep system-locale"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale"
+              set: true
+            - flag: "-w /etc/issue -p wa -k system-locale"
+              set: true
+            - flag: "-w /etc/issue.net -p wa -k system-locale"
+              set: true
+            - flag: "-w /etc/hosts -p wa -k system-locale"
+              set: true
+            - flag: "-w /etc/sysconfig/network -p wa -k system-locale"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
+          -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
+          -w /etc/issue -p wa -k system-locale
+          -w /etc/issue.net -p wa -k system-locale
+          -w /etc/hosts -p wa -k system-locale
+          -w /etc/sysconfig/network -p wa -k system-locale
+        scored: true
+      - id: 4.1.8.a
+        description: "Ensure events that modify the system's Mandatory Access Controls are collected"
+        sub_checks:
+          - check:
+              audit: "grep MAC-policy /etc/audit/rules.d/*.rules"
+              constraints:
+                lsm:
+                  - selinux
+              tests:
+                bin_op: and
+                test_items:
+                  - flag: "-w /etc/selinux/ -p wa -k MAC-policy"
+                    set: true
+                  - flag: "-w /usr/share/selinux/ -p wa -k MAC-policy"
+                    set: true
+              remediation: |
                 On systems using SELinux Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
                 Example: vi /etc/audit/rules.d/audit.rules
                 and add the following lines:
                 -w /etc/selinux/ -p wa -k MAC-policy
                 -w /usr/share/selinux/ -p wa -k MAC-policy
-      - check:
-          audit: "grep MAC-policy /etc/audit/rules.d/*.rules"  
-          constraints:
-            lsm:
-            - apparmor
-          tests:
-            bin_op: and
-            test_items:
-            - flag: "-w /etc/apparmor/ -p wa -k MAC-policy"
-              set: true
-            - flag: "-w /etc/apparmor.d/ -p wa -k MAC-policy"
-              set: true                       
-          remediation: |
-                On systems using AppArmor Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-                Example: vi /etc/audit/rules.d/audit.rules 
+          - check:
+              audit: "grep MAC-policy /etc/audit/rules.d/*.rules"
+              constraints:
+                lsm:
+                  - apparmor
+              tests:
+                bin_op: and
+                test_items:
+                  - flag: "-w /etc/apparmor/ -p wa -k MAC-policy"
+                    set: true
+                  - flag: "-w /etc/apparmor.d/ -p wa -k MAC-policy"
+                    set: true
+              remediation: |
+                On systems using AppArmor Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+                Example: vi /etc/audit/rules.d/audit.rules
                 and add the following lines:
                 -w /etc/apparmor/ -p wa -k MAC-policy
                 -w /etc/apparmor.d/ -p wa -k MAC-policy
-                
-      scored: true
-    - id: 4.1.8.b 
-      description: "Ensure events that modify the system's Mandatory Access Controls are collected"
-      sub_checks:
-      - check:
-          audit: "auditctl -l | grep MAC-policy"   
-          constraints:
-            lsm:
-            - selinux
-          tests:
-            bin_op: and
-            test_items:
-            - flag: "-w /etc/selinux -p wa -k MAC-policy"
-              set: true
-            - flag: "-w /usr/share/selinux -p wa -k MAC-policy"
-              set: true                       
-          remediation: |
+
+        scored: true
+      - id: 4.1.8.b
+        description: "Ensure events that modify the system's Mandatory Access Controls are collected"
+        sub_checks:
+          - check:
+              audit: "auditctl -l | grep MAC-policy"
+              constraints:
+                lsm:
+                  - selinux
+              tests:
+                bin_op: and
+                test_items:
+                  - flag: "-w /etc/selinux -p wa -k MAC-policy"
+                    set: true
+                  - flag: "-w /usr/share/selinux -p wa -k MAC-policy"
+                    set: true
+              remediation: |
                 On systems using SELinux Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
                 Example: vi /etc/audit/rules.d/audit.rules
                 and add the following lines:
                 -w /etc/selinux/ -p wa -k MAC-policy
                 -w /usr/share/selinux/ -p wa -k MAC-policy
-      - check:
-          audit: "auditctl -l | grep MAC-policy"   
-          constraints:
-            lsm:
-            - apparmor
-          tests:
-            bin_op: and
-            test_items:
-            - flag: "-w /etc/apparmor -p wa -k MAC-policy"
-              set: true
-            - flag: "-w /etc/apparmor.d -p wa -k MAC-policy"
-              set: true                       
-          remediation: |
-                On systems using AppArmor Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-                Example: vi /etc/audit/rules.d/audit.rules 
+          - check:
+              audit: "auditctl -l | grep MAC-policy"
+              constraints:
+                lsm:
+                  - apparmor
+              tests:
+                bin_op: and
+                test_items:
+                  - flag: "-w /etc/apparmor -p wa -k MAC-policy"
+                    set: true
+                  - flag: "-w /etc/apparmor.d -p wa -k MAC-policy"
+                    set: true
+              remediation: |
+                On systems using AppArmor Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+                Example: vi /etc/audit/rules.d/audit.rules
                 and add the following lines:
                 -w /etc/apparmor/ -p wa -k MAC-policy
                 -w /etc/apparmor.d/ -p wa -k MAC-policy
-                
-      scored: true
-    - id: 4.1.9.a
-      description: "Ensure login and logout events are collected"
-      audit: "grep logins /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-w /var/log/faillog -p wa -k logins"
-          set: true
-        - flag: "-w /var/log/lastlog -p wa -k logins"
-          set: true
-        - flag: "-w /var/log/tallylog -p wa -k logins"
-          set: true                       
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /var/log/faillog -p wa -k logins
-            -w /var/log/lastlog -p wa -k logins
-            -w /var/log/tallylog -p wa -k logins
-            
-      scored: true                  
-    
-        
-    - id: 4.1.9.b
-      description: "Ensure login and logout events are collected"
-      audit: "auditctl -l | grep logins"   
-      tests:
-        test_items:
-        - flag: "-w /var/log/faillog -p wa -k logins"
-          set: true
-        - flag: "-w /var/log/lastlog -p wa -k logins"
-          set: true
-        - flag: "-w /var/log/tallylog -p wa -k logins"
-          set: true                       
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /var/log/faillog -p wa -k logins
-            -w /var/log/lastlog -p wa -k logins
-            -w /var/log/tallylog -p wa -k logins
-            
-      scored: true                  
-            
-    - id: 4.1.10.a
-      description: "Ensure session initiation information is collected"
-      audit: "grep -E '(session|logins)' /etc/audit/rules.d/*.rules"   
-      tests:
-        test_items:
-        - flag: "-w /var/run/utmp -p wa -k session"
-          set: true
-        - flag: "-w /var/log/wtmp -p wa -k logins"
-          set: true
-        - flag: "-w /var/log/btmp -p wa -k logins"
-          set: true                       
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /var/run/utmp -p wa -k session
-            -w /var/log/wtmp -p wa -k logins
-            -w /var/log/btmp -p wa -k logins
-            
-      scored: true                  
-            
-    - id: 4.1.10.b
-      description: "Ensure session initiation information is collected"
-      audit: "auditctl -l | grep -E '(session|logins)'"   
-      tests:
-        test_items:
-        - flag: "-w /var/run/utmp -p wa -k session"
-          set: true
-        - flag: "-w /var/log/wtmp -p wa -k logins"
-          set: true
-        - flag: "-w /var/log/btmp -p wa -k logins"
-          set: true                        
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /var/run/utmp -p wa -k session
-            -w /var/log/wtmp -p wa -k logins
-            -w /var/log/btmp -p wa -k logins
-            
-      scored: true                  
-            
-    - id: 4.1.11.a
-      description: "Ensure discretionary access control permission modification events are collected"
-      audit: "grep perm_mod /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod"
-          set: true                      
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
-            
-      scored: true
-    - id: 4.1.11.b
-      description: "Ensure discretionary access control permission modification events are collected"
-      audit: "auditctl -l | grep perm_mod"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=500 -F auid!=-1 -F key=perm_mod"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=500 -F auid!=-1 -F key=perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S chown,fchown,lchown,fchownat -F auid>=500 -F auid!=-1 -F key=perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F auid>=500 -F auid!=-1 -F key=perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid>=500 -F auid!=-1 -F key=perm_mod"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid>=500 -F auid!=-1 -F key=perm_mod"
-          set: true                      
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
-            -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
-            
-      scored: true
-    - id: 4.1.12.a
-      description: "Ensure unsuccessful unauthorized file access attempts are collected"
-      audit: "grep access /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access"
-          set: true                                  
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
-            -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
-            -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
-            -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
-            
-      scored: true                  
-    - id: 4.1.12.b
-      description: "Ensure unsuccessful unauthorized file access attempts are collected"
-      audit: "auditctl -l | grep access"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat -F exit=-EACCES -F auid>=500 -F auid!=-1 -F key=access"
-          set: true  
-        - flag: "-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat -F exit=-EACCES -F auid>=500 -F auid!=-1 -F key=access"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat -F exit=-EPERM -F auid>=500 -F auid!=-1 -F key=access"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat -F exit=-EPERM -F auid>=500 -F auid!=-1 -F key=access"
-          set: true                                  
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
-            -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
-            -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
-            -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
-            
-      scored: true                  
-    - id: 4.1.13
-      description: "Ensure use of privileged commands is collected"
-      audit: "find <partition> -xdev \\( -perm -4000 -o -perm -2000 \\) -type f | awk '{print \"-a always,exit -F path=\" $1 \" -F perm=x -F auid>=500 -F auid!=4294967295 \ -k privileged\" }' "   
-      type: "manual"          
-      remediation: |
-            To remediate this issue, the system administrator will have to execute a find command to 
-            locate all the privileged programs and then add an audit line for each one of them. 
-            The audit parameters associated with this are as follows: 
-            -F path=" $1 " - will populate each file name found through the find command and 
-            processed by awk. -F perm=x - will write an audit record if the file is executed. 
-            -F auid>=500 - will write a record if the user executing the command is not a privileged user.
-            -F auid!= 4294967295 - will ignore Daemon events 
-            All audit records should be tagged with the identifier "privileged". 
-            Run the following command replacing with a list of partitions where programs can be 
-            executed from on your system: 
-            # find <partition> -xdev \( -perm -4000 -o -perm -2000 \) -type f | awk 
-            '{print \ 
-            "-a always,exit -F path=" $1 " -F perm=x -F auid>=500 -F auid!=4294967295 \
-            -k privileged" }'
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            And add all resulting lines to the file.
-      scored: true                  
-                  
-            
-    - id: 4.1.14.a
-      description: "Ensure successful file system mounts are collected"
-      audit: "grep mounts /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts"
-          set: true                       
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
-            -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
-            
-      scored: true                  
 
-    - id: 4.1.14.b
-      description: "Ensure successful file system mounts are collected"
-      audit: "auditctl -l | grep mounts"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=-1 -F key=mounts"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=-1 -F key=mounts"
-          set: true                       
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
-            -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
-            
-      scored: true  
-
-    - id: 4.1.15.a
-      description: "Ensure file deletion events by users are collected"
-      audit: "grep delete /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
-          set: true              
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
-            -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
-            
-      scored: true                  
-
-    - id: 4.1.15.b
-      description: "Ensure file deletion events by users are collected"
-      audit: "auditctl -l | grep delete"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-a always,exit -F arch=b64 -S rename,unlink,unlinkat,renameat -F auid>=500 -F auid!=-1 -F key=delete"
-          set: true
-        - flag: "-a always,exit -F arch=b32 -S unlink,rename,unlinkat,renameat -F auid>=500 -F auid!=-1 -F key=delete"
-          set: true              
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
-            -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
-            
-      scored: true                                     
-
-    - id: 4.1.16.a
-      description: "Ensure changes to system administration scope (sudoers) is collected"
-      audit: "grep scope /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-w /etc/sudoers -p wa -k scope"
-          set: true
-        - flag: "-w /etc/sudoers.d/ -p wa -k scope"
-          set: true                       
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /etc/sudoers -p wa -k scope
-            -w /etc/sudoers.d/ -p wa -k scope
-            
-      scored: true                  
-            
-    - id: 4.1.16.b
-      description: "Ensure changes to system administration scope (sudoers) is collected"
-      audit: "auditctl -l | grep scope"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-w /etc/sudoers -p wa -k scope"
-          set: true
-        - flag: "-w /etc/sudoers.d -p wa -k scope"
-          set: true                       
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /etc/sudoers -p wa -k scope
-            -w /etc/sudoers.d/ -p wa -k scope
-            
-      scored: true                     
-      remediation: |
-            Add the following line to the `/etc/audit/rules.d/*.rules` file:
-            
-            -w /etc/sudoers -p wa -k scope
-            -w /etc/sudoers.d/ -p wa -k scope
-            
-      scored: true                  
-            
-    - id: 4.1.17.a
-      description: "Ensure system administrator actions (sudolog) are collected"
-      audit: "grep actions /etc/audit/rules.d/*.rules"   
-      tests:
-        test_items:
-        - flag: "-w /var/log/sudo.log -p wa -k actions"
-          compare:
-            op: eq
-            value: "-w /var/log/sudo.log -p wa -k actions"
-          set: true                        
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /var/log/sudo.log -p wa -k actions
-            
-      scored: true                  
-            
-    - id: 4.1.17.b
-      description: "Ensure system administrator actions (sudolog) are collected"
-      audit: "auditctl -l | grep actions"   
-      tests:
-        test_items:
-        - flag: "-w /var/log/sudo.log -p wa -k actions"
-          set: true                      
-      remediation: |
-            Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /var/log/sudo.log -p wa -k actions
-            
-      scored: true                  
-            
-    - id: 4.1.18.a
-      description: "Ensure kernel module loading and unloading is collected"
-      audit: "grep modules /etc/audit/rules.d/*.rules"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-w /sbin/insmod -p x -k modules"
-          set: true
-        - flag: "-w /sbin/rmmod -p x -k modules"
-          set: true
-        - flag: "-w /sbin/modprobe -p x -k modules"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S init_module -S delete_module -k modules"
-          set: true                        
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /sbin/insmod -p x -k modules
-            -w /sbin/rmmod -p x -k modules
-            -w /sbin/modprobe -p x -k modules
-            -a always,exit -F arch=b64 -S init_module -S delete_module -k modules
-            
-      scored: true                  
-
-    - id: 4.1.18.b
-      description: "Ensure kernel module loading and unloading is collected"
-      audit: "auditctl -l | grep modules" 
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "-w /sbin/insmod -p x -k modules"
-          set: true
-        - flag: "-w /sbin/rmmod -p x -k modules"
-          set: true
-        - flag: "-w /sbin/modprobe -p x -k modules"
-          set: true
-        - flag: "-a always,exit -F arch=b64 -S init_module,delete_module -F key=modules"
-          set: true                        
-      remediation: |
-            For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules 
-            Example: vi /etc/audit/rules.d/audit.rules 
-            and add the following lines:
-            -w /sbin/insmod -p x -k modules
-            -w /sbin/rmmod -p x -k modules
-            -w /sbin/modprobe -p x -k modules
-            -a always,exit -F arch=b64 -S init_module -S delete_module -k modules
-            
-      scored: true
-
-      scored: true              
-    - id: 4.1.19
-      description: "Ensure the audit configuration is immutable"
-      audit: "grep ^\\s*[^#] /etc/audit/rules.d/*.rules | tail -1"   
-      tests:
-        test_items:
-        - flag: "-e 2"
-          set: true                        
-      remediation: |
-            Edit or create the file /etc/audit/rules.d/99-finalize.rules and add the line
-            -e 2
-            at the end of the file
-      scored: true 
-
-- id: 4.2
-  description: "Configure Logging"
-- id: 4.2.1
-  description: "Configure rsyslog"
-  checks:
-    - id: 4.2.1.1
-      description: "Ensure rsyslog is installed"
-      sub_checks:
-      - check:
-          audit: "rpm -q rsyslog"   
-          constraints:          
-            platform:
-            - rhel7
-            syslog:
-            - rsyslog
-          tests:
-            test_items:
-            - flag: "is not installed"
-              set: false
-          remediation: |
-                Install rsyslog or `syslog-ng` using the appropriate package manager or manual installation:
-                
-                # yum install rsyslog
-                
-                
-                # apt-get install rsyslog
-                
-                
-                # zypper install rsyslog
-                
-                The previous commands install `rsyslog` , use the appropriate package if `syslog-ng` is desired.
-      - check:
-          audit: "dpkg -s rsyslog"   
-          constraints:          
-            platform:
-            - ubuntu16
-            syslog:
-            - rsyslog
-          tests:
-            test_items:
-            - flag: "install ok installed"
+        scored: true
+      - id: 4.1.9.a
+        description: "Ensure login and logout events are collected"
+        audit: "grep logins /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-w /var/log/faillog -p wa -k logins"
               set: true
-          remediation: |
-                Install rsyslog or `syslog-ng` using the appropriate package manager or manual installation:
-                
-                # yum install rsyslog
-                
-                
-                # apt-get install rsyslog
-                
-                
-                # zypper install rsyslog
-                
-                The previous commands install `rsyslog` , use the appropriate package if `syslog-ng` is desired.
-      - check:
-          audit: "apt-cache show rsyslog"   
-          constraints:          
-            platform:
-            - ubuntu18
-            syslog:
-            - rsyslog
-          tests:
-            test_items:
-            - flag: "Installed-Size:"
+            - flag: "-w /var/log/lastlog -p wa -k logins"
               set: true
-          remediation: |
+            - flag: "-w /var/log/tallylog -p wa -k logins"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /var/log/faillog -p wa -k logins
+          -w /var/log/lastlog -p wa -k logins
+          -w /var/log/tallylog -p wa -k logins
+
+        scored: true
+
+      - id: 4.1.9.b
+        description: "Ensure login and logout events are collected"
+        audit: "auditctl -l | grep logins"
+        tests:
+          test_items:
+            - flag: "-w /var/log/faillog -p wa -k logins"
+              set: true
+            - flag: "-w /var/log/lastlog -p wa -k logins"
+              set: true
+            - flag: "-w /var/log/tallylog -p wa -k logins"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /var/log/faillog -p wa -k logins
+          -w /var/log/lastlog -p wa -k logins
+          -w /var/log/tallylog -p wa -k logins
+
+        scored: true
+
+      - id: 4.1.10.a
+        description: "Ensure session initiation information is collected"
+        audit: "grep -E '(session|logins)' /etc/audit/rules.d/*.rules"
+        tests:
+          test_items:
+            - flag: "-w /var/run/utmp -p wa -k session"
+              set: true
+            - flag: "-w /var/log/wtmp -p wa -k logins"
+              set: true
+            - flag: "-w /var/log/btmp -p wa -k logins"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /var/run/utmp -p wa -k session
+          -w /var/log/wtmp -p wa -k logins
+          -w /var/log/btmp -p wa -k logins
+
+        scored: true
+
+      - id: 4.1.10.b
+        description: "Ensure session initiation information is collected"
+        audit: "auditctl -l | grep -E '(session|logins)'"
+        tests:
+          test_items:
+            - flag: "-w /var/run/utmp -p wa -k session"
+              set: true
+            - flag: "-w /var/log/wtmp -p wa -k logins"
+              set: true
+            - flag: "-w /var/log/btmp -p wa -k logins"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /var/run/utmp -p wa -k session
+          -w /var/log/wtmp -p wa -k logins
+          -w /var/log/btmp -p wa -k logins
+
+        scored: true
+
+      - id: 4.1.11.a
+        description: "Ensure discretionary access control permission modification events are collected"
+        audit: "grep perm_mod /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+
+        scored: true
+      - id: 4.1.11.b
+        description: "Ensure discretionary access control permission modification events are collected"
+        audit: "auditctl -l | grep perm_mod"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=500 -F auid!=-1 -F key=perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=500 -F auid!=-1 -F key=perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S chown,fchown,lchown,fchownat -F auid>=500 -F auid!=-1 -F key=perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F auid>=500 -F auid!=-1 -F key=perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid>=500 -F auid!=-1 -F key=perm_mod"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid>=500 -F auid!=-1 -F key=perm_mod"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+          -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+
+        scored: true
+      - id: 4.1.12.a
+        description: "Ensure unsuccessful unauthorized file access attempts are collected"
+        audit: "grep access /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+          -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+          -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+          -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+
+        scored: true
+      - id: 4.1.12.b
+        description: "Ensure unsuccessful unauthorized file access attempts are collected"
+        audit: "auditctl -l | grep access"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat -F exit=-EACCES -F auid>=500 -F auid!=-1 -F key=access"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat -F exit=-EACCES -F auid>=500 -F auid!=-1 -F key=access"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat -F exit=-EPERM -F auid>=500 -F auid!=-1 -F key=access"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat -F exit=-EPERM -F auid>=500 -F auid!=-1 -F key=access"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+          -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+          -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+          -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+
+        scored: true
+      - id: 4.1.13
+        description: "Ensure use of privileged commands is collected"
+        audit: "find <partition> -xdev \\( -perm -4000 -o -perm -2000 \\) -type f | awk '{print \"-a always,exit -F path=\" $1 \" -F perm=x -F auid>=500 -F auid!=4294967295 \ -k privileged\" }' "
+        type: "manual"
+        remediation: |
+          To remediate this issue, the system administrator will have to execute a find command to
+          locate all the privileged programs and then add an audit line for each one of them.
+          The audit parameters associated with this are as follows:
+          -F path=" $1 " - will populate each file name found through the find command and
+          processed by awk. -F perm=x - will write an audit record if the file is executed.
+          -F auid>=500 - will write a record if the user executing the command is not a privileged user.
+          -F auid!= 4294967295 - will ignore Daemon events
+          All audit records should be tagged with the identifier "privileged".
+          Run the following command replacing with a list of partitions where programs can be
+          executed from on your system:
+          # find <partition> -xdev \( -perm -4000 -o -perm -2000 \) -type f | awk
+          '{print \
+          "-a always,exit -F path=" $1 " -F perm=x -F auid>=500 -F auid!=4294967295 \
+          -k privileged" }'
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          And add all resulting lines to the file.
+        scored: true
+
+      - id: 4.1.14.a
+        description: "Ensure successful file system mounts are collected"
+        audit: "grep mounts /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
+          -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
+
+        scored: true
+
+      - id: 4.1.14.b
+        description: "Ensure successful file system mounts are collected"
+        audit: "auditctl -l | grep mounts"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=-1 -F key=mounts"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=-1 -F key=mounts"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
+          -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
+
+        scored: true
+
+      - id: 4.1.15.a
+        description: "Ensure file deletion events by users are collected"
+        audit: "grep delete /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
+          -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
+
+        scored: true
+
+      - id: 4.1.15.b
+        description: "Ensure file deletion events by users are collected"
+        audit: "auditctl -l | grep delete"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-a always,exit -F arch=b64 -S rename,unlink,unlinkat,renameat -F auid>=500 -F auid!=-1 -F key=delete"
+              set: true
+            - flag: "-a always,exit -F arch=b32 -S unlink,rename,unlinkat,renameat -F auid>=500 -F auid!=-1 -F key=delete"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
+          -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
+
+        scored: true
+
+      - id: 4.1.16.a
+        description: "Ensure changes to system administration scope (sudoers) is collected"
+        audit: "grep scope /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-w /etc/sudoers -p wa -k scope"
+              set: true
+            - flag: "-w /etc/sudoers.d/ -p wa -k scope"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /etc/sudoers -p wa -k scope
+          -w /etc/sudoers.d/ -p wa -k scope
+
+        scored: true
+
+      - id: 4.1.16.b
+        description: "Ensure changes to system administration scope (sudoers) is collected"
+        audit: "auditctl -l | grep scope"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-w /etc/sudoers -p wa -k scope"
+              set: true
+            - flag: "-w /etc/sudoers.d -p wa -k scope"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /etc/sudoers -p wa -k scope
+          -w /etc/sudoers.d/ -p wa -k scope
+
+        scored: true
+
+      - id: 4.1.17.a
+        description: "Ensure system administrator actions (sudolog) are collected"
+        audit: "grep actions /etc/audit/rules.d/*.rules"
+        tests:
+          test_items:
+            - flag: "-w /var/log/sudo.log -p wa -k actions"
+              compare:
+                op: eq
+                value: "-w /var/log/sudo.log -p wa -k actions"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /var/log/sudo.log -p wa -k actions
+
+        scored: true
+
+      - id: 4.1.17.b
+        description: "Ensure system administrator actions (sudolog) are collected"
+        audit: "auditctl -l | grep actions"
+        tests:
+          test_items:
+            - flag: "-w /var/log/sudo.log -p wa -k actions"
+              set: true
+        remediation: |
+          Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /var/log/sudo.log -p wa -k actions
+
+        scored: true
+
+      - id: 4.1.18.a
+        description: "Ensure kernel module loading and unloading is collected"
+        audit: "grep modules /etc/audit/rules.d/*.rules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-w /sbin/insmod -p x -k modules"
+              set: true
+            - flag: "-w /sbin/rmmod -p x -k modules"
+              set: true
+            - flag: "-w /sbin/modprobe -p x -k modules"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S init_module -S delete_module -k modules"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /sbin/insmod -p x -k modules
+          -w /sbin/rmmod -p x -k modules
+          -w /sbin/modprobe -p x -k modules
+          -a always,exit -F arch=b64 -S init_module -S delete_module -k modules
+
+        scored: true
+
+      - id: 4.1.18.b
+        description: "Ensure kernel module loading and unloading is collected"
+        audit: "auditctl -l | grep modules"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "-w /sbin/insmod -p x -k modules"
+              set: true
+            - flag: "-w /sbin/rmmod -p x -k modules"
+              set: true
+            - flag: "-w /sbin/modprobe -p x -k modules"
+              set: true
+            - flag: "-a always,exit -F arch=b64 -S init_module,delete_module -F key=modules"
+              set: true
+        remediation: |
+          For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
+          Example: vi /etc/audit/rules.d/audit.rules
+          and add the following lines:
+          -w /sbin/insmod -p x -k modules
+          -w /sbin/rmmod -p x -k modules
+          -w /sbin/modprobe -p x -k modules
+          -a always,exit -F arch=b64 -S init_module -S delete_module -k modules
+        scored: true
+
+      - id: 4.1.19
+        description: "Ensure the audit configuration is immutable"
+        audit: "grep ^\\s*[^#] /etc/audit/rules.d/*.rules | tail -1"
+        tests:
+          test_items:
+            - flag: "-e 2"
+              set: true
+        remediation: |
+          Edit or create the file /etc/audit/rules.d/99-finalize.rules and add the line
+          -e 2
+          at the end of the file
+        scored: true
+
+  - id: 4.2
+    description: "Configure Logging"
+  - id: 4.2.1
+    description: "Configure rsyslog"
+    checks:
+      - id: 4.2.1.1
+        description: "Ensure rsyslog is installed"
+        sub_checks:
+          - check:
+              audit: "rpm -q rsyslog"
+              constraints:
+                platform:
+                  - rhel7
+                syslog:
+                  - rsyslog
+              tests:
+                test_items:
+                  - flag: "is not installed"
+                    set: false
+              remediation: |
                 Install rsyslog or `syslog-ng` using the appropriate package manager or manual installation:
-                
+
                 # yum install rsyslog
-                
-                
+
+
                 # apt-get install rsyslog
-                
-                
+
+
                 # zypper install rsyslog
-                
+
                 The previous commands install `rsyslog` , use the appropriate package if `syslog-ng` is desired.
-      scored: true
-    - id: 4.2.1.2
-      description: "Ensure rsyslog Service is enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list rsyslog"
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "rsyslog 0:off 1:off 2:on 3:on 4:on 5:on 6:off"
-              set: true                        
-          remediation: |
+          - check:
+              audit: "dpkg -s rsyslog"
+              constraints:
+                platform:
+                  - ubuntu16
+                syslog:
+                  - rsyslog
+              tests:
+                test_items:
+                  - flag: "install ok installed"
+                    set: true
+              remediation: |
+                Install rsyslog or `syslog-ng` using the appropriate package manager or manual installation:
+
+                # yum install rsyslog
+
+
+                # apt-get install rsyslog
+
+
+                # zypper install rsyslog
+
+                The previous commands install `rsyslog` , use the appropriate package if `syslog-ng` is desired.
+          - check:
+              audit: "apt-cache show rsyslog"
+              constraints:
+                platform:
+                  - ubuntu18
+                syslog:
+                  - rsyslog
+              tests:
+                test_items:
+                  - flag: "Installed-Size:"
+                    set: true
+              remediation: |
+                Install rsyslog or `syslog-ng` using the appropriate package manager or manual installation:
+
+                # yum install rsyslog
+
+
+                # apt-get install rsyslog
+
+
+                # zypper install rsyslog
+
+                The previous commands install `rsyslog` , use the appropriate package if `syslog-ng` is desired.
+        scored: true
+      - id: 4.2.1.2
+        description: "Ensure rsyslog Service is enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list rsyslog"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "rsyslog 0:off 1:off 2:on 3:on 4:on 5:on 6:off"
+                    set: true
+              remediation: |
                 Run one of the following commands to enable `rsyslog` :
-                
+
                 # chkconfig rsyslog on
-                
-                
+
+
                 # systemctl enable rsyslog
-                
-                
+
+
                 # update-rc.d rsyslog enable
-      - check:
-          audit: "systemctl is-enabled rsyslog"
-          constraints:          
-            platform:
-            - rhel7
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: true                        
-          remediation: |
+          - check:
+              audit: "systemctl is-enabled rsyslog"
+              constraints:
+                platform:
+                  - rhel7
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: true
+              remediation: |
                 Run one of the following commands to enable `rsyslog` :
-                
+
                 # chkconfig rsyslog on
-                
-                
+
+
                 # systemctl enable rsyslog
-                
-                
+
+
                 # update-rc.d rsyslog enable
-      - check:
-          audit: "ls /etc/rc*.d | grep rsyslog"
-          type: manual
-          constraints:          
-            platform:
-            - ubuntuOptional
-          tests:
-            test_items:
-            - flag: ""
-              set: true                        
-          remediation: |
+          - check:
+              audit: "ls /etc/rc*.d | grep rsyslog"
+              type: manual
+              constraints:
+                platform:
+                  - ubuntuOptional
+              tests:
+                test_items:
+                  - flag: ""
+                    set: true
+              remediation: |
                 Run one of the following commands to enable `rsyslog` :
-                
+
                 # chkconfig rsyslog on
-                
-                
+
+
                 # systemctl enable rsyslog
-                
-                
+
+
                 # update-rc.d rsyslog enable
-      scored: true 
-    - id: 4.2.1.3
-      description: "Ensure logging is configured"
-      sub_checks:
-      - check:
-          audit: "ls -l /var/log/"   
-          constraints:          
-            syslog:
-            - rsyslog
-          type: manual      
-          remediation: |
+        scored: true
+      - id: 4.2.1.3
+        description: "Ensure logging is configured"
+        sub_checks:
+          - check:
+              audit: "ls -l /var/log/"
+              constraints:
+                syslog:
+                  - rsyslog
+              type: manual
+              remediation: |
                 Edit the following lines in the `/etc/rsyslog.conf` and `/etc/rsyslog.d/*.conf` files as appropriate for your environment:
-                
+
                 *.emerg :omusrmsg:*
                 mail.* -/var/log/mail
                 mail.info -/var/log/mail.info
@@ -7031,2176 +6998,2142 @@ groups:
                 local2,local3.* -/var/log/localmessages
                 local4,local5.* -/var/log/localmessages
                 local6,local7.* -/var/log/localmessages
-                
+
                 Run the following command to reload the `rsyslogd` configuration:
-                
-                # pkill -HUP rsyslogd          
-      scored: false
-    - id: 4.2.1.4
-      description: "Ensure rsyslog default file permissions configured"
-      sub_checks:
-      - check:
-          audit: "grep ^\\$FileCreateMode /etc/rsyslog.conf /etc/rsyslog.d/*.conf -h | tr \"$\" \" \" "   
-          constraints:          
-            syslog:
-            - rsyslog
-          tests:
-            test_items:
-            - flag: "FileCreateMode"
+
+                # pkill -HUP rsyslogd
+        scored: false
+      - id: 4.2.1.4
+        description: "Ensure rsyslog default file permissions configured"
+        sub_checks:
+          - check:
+              audit: "grep ^\\$FileCreateMode /etc/rsyslog.conf /etc/rsyslog.d/*.conf -h | tr \"$\" \" \" "
+              constraints:
+                syslog:
+                  - rsyslog
+              tests:
+                test_items:
+                  - flag: "FileCreateMode"
+                    compare:
+                      op: bitmask
+                      value: "0640"
+                    set: true
+              remediation: |
+                Edit the `/etc/rsyslog.conf` and `/etc/rsyslog.d/*.conf` files and set `$FileCreateMode` to `0640` or more restrictive:
+
+                $FileCreateMode 0640
+        scored: true
+      - id: 4.2.1.5
+        description: "Ensure rsyslog is configured to send logs to a remote log host"
+        sub_checks:
+          - check:
+              audit: 'grep "^*.*[^I][^I]*@" /etc/rsyslog.conf /etc/rsyslog.d/*.conf'
+              constraints:
+                syslog:
+                  - rsyslog
+              type: manual
+              remediation: |
+                Edit the `/etc/rsyslog.conf` and `/etc/rsyslog.d/*.conf` files and add the following line (where `loghost.example.com` is the name of your central log host).
+
+                *.* @@loghost.example.com
+
+                Run the following command to reload the `rsyslogd` configuration:
+
+                # pkill -HUP rsyslogd
+        scored: true
+      - id: 4.2.1.6.a
+        description: "Ensure remote rsyslog messages are only accepted on designated log hosts."
+        sub_checks:
+          - check:
+              audit: "grep ^\\$ModLoad /etc/rsyslog.conf /etc/rsyslog.d/*.conf"
+              constraints:
+                syslog:
+                  - rsyslog
+              tests:
+                test_items:
+                  - flag: "\\$ModLoad imtcp"
+                    set: true
+              remediation: |
+                For hosts that are designated as log hosts, edit the `/etc/rsyslog.conf` file and un-comment or add the following lines:
+
+                $ModLoad imtcp
+                $InputTCPServerRun 514
+
+                For hosts that are not designated as log hosts, edit the `/etc/rsyslog.conf` file and comment or remove the following lines:
+
+                # $ModLoad imtcp
+                # $InputTCPServerRun 514
+
+                Run the following command to reload the `rsyslogd` configuration:
+
+                # pkill -HUP rsyslogd
+
+        scored: false
+      - id: 4.2.1.6.b
+        description: "Ensure remote rsyslog messages are only accepted on designated log hosts."
+        sub_checks:
+          - check:
+              audit: "grep ^\\$InputTCPServerRun /etc/rsyslog.conf /etc/rsyslog.d/*.conf"
+              constraints:
+                syslog:
+                  - rsyslog
+              tests:
+                test_items:
+                  - flag: "\\$InputTCPServerRun 514"
+                    set: true
+              remediation: |
+                For hosts that are designated as log hosts, edit the `/etc/rsyslog.conf` file and un-comment or add the following lines:
+
+                $ModLoad imtcp
+                $InputTCPServerRun 514
+
+                For hosts that are not designated as log hosts, edit the `/etc/rsyslog.conf` file and comment or remove the following lines:
+
+                # $ModLoad imtcp
+                # $InputTCPServerRun 514
+
+                Run the following command to reload the `rsyslogd` configuration:
+
+                # pkill -HUP rsyslogd
+        scored: false
+  - id: 4.2.2
+    description: "Configure journald"
+    checks:
+      - id: 4.2.2.1
+        description: "Ensure journald is configured to send logs to rsyslog"
+        audit: "grep -e ForwardToSyslog /etc/systemd/journald.conf"
+        tests:
+          test_items:
+            - flag: "ForwardToSyslog=yes"
+              set: true
+        remediation: |
+          Edit the /etc/systemd/journald.conf file and add the following line:
+          ForwardToSyslog=yes
+
+        scored: true
+      - id: 4.2.2.2
+        description: "Ensure journald is configured to compress large log files (Scored)"
+        audit: "grep -e Compress /etc/systemd/journald.conf"
+        tests:
+          test_items:
+            - flag: "Compress=yes"
+              set: true
+        remediation: |
+          Edit the /etc/systemd/journald.conf file and add the following line:
+          Compress=yes
+
+        scored: true
+      - id: 4.2.2.3
+        description: "Ensure journald is configured to write logfiles to persistent disk"
+        audit: "grep -e Storage /etc/systemd/journald.conf"
+        tests:
+          test_items:
+            - flag: "Storage=persistent"
+              set: true
+        remediation: |
+          Edit the /etc/systemd/journald.conf file and add the following line:
+          Storage=persistent
+
+        scored: true
+      - id: 4.2.3
+        description: "Ensure permissions on all logfiles are configured"
+        audit: "find /var/log -type f -ls"
+        type: manual
+        remediation: |
+          Run the following commands to set permissions on all existing log files:
+          find /var/log -type f -exec chmod g-wx,o-rwx "{}" + -o -type d -exec chmod g-w,o-rwx "{}" +
+        scored: true
+      - id: 4.3
+        description: "Ensure logrotate is configured"
+        audit: "cat /etc/logrotate.conf; cat /etc/logrotate.d/* ;"
+        type: manual
+        remediation: |
+          Edit `/etc/logrotate.conf` and `/etc/logrotate.d/*` to ensure logs are rotated according to site policy.
+        scored: false
+  - id: 5
+    description: "Access, Authentication and Authorization"
+  - id: 5.1
+    description: "Configure cron"
+    checks:
+      - id: 5.1.1
+        description: "Ensure cron daemon is enabled"
+        sub_checks:
+          - check:
+              audit: "chkconfig --list crond"
+              constraints:
+                platform:
+                  - rhel6
+              tests:
+                test_items:
+                  - flag: "2:on 3:on 4:on 5:on"
+                    set: true
+              remediation: |
+                Based on your system configuration, run the appropriate one of the following commands to enable `cron` :
+
+                # chkconfig crond on
+
+
+                # systemctl enable crond
+
+
+                # update-rc.d crond enable
+          - check:
+              audit: "systemctl is-enabled crond"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: true
+              remediation: |
+                Based on your system configuration, run the appropriate one of the following commands to enable `cron` :
+
+                # chkconfig crond on
+
+
+                # systemctl enable crond
+
+
+                # update-rc.d crond enable
+          - check:
+              audit: "systemctl is-enabled cron"
+              constraints:
+                platform:
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "enabled"
+                    set: true
+              remediation: |
+                Based on your system configuration, run the appropriate one of the following commands to enable `cron` :
+
+                # chkconfig cron on
+
+
+                # systemctl enable cron
+
+
+                # update-rc.d cron enable
+        scored: true
+      - id: 5.1.2
+        description: "Ensure permissions on /etc/crontab are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/crontab"
+        tests:
+          test_items:
+            - flag: "600/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set ownership and permissions on `/etc/crontab` :
+
+          # chown root:root /etc/crontab
+          # chmod og-rwx /etc/crontab
+
+        scored: true
+
+      - id: 5.1.3
+        description: "Ensure permissions on /etc/cron.hourly are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.hourly"
+        tests:
+          test_items:
+            - flag: "700/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set ownership and permissions on `/etc/cron.hourly` :
+
+          # chown root:root /etc/cron.hourly
+          # chmod og-rwx /etc/cron.hourly
+
+        scored: true
+
+      - id: 5.1.4
+        description: "Ensure permissions on /etc/cron.daily are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.daily"
+        tests:
+          test_items:
+            - flag: "700/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set ownership and permissions on `/etc/cron.daily` :
+
+          # chown root:root /etc/cron.daily
+          # chmod og-rwx /etc/cron.daily
+
+        scored: true
+
+      - id: 5.1.5
+        description: "Ensure permissions on /etc/cron.weekly are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.weekly"
+        tests:
+          test_items:
+            - flag: "700/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set ownership and permissions on `/etc/cron.weekly` :
+
+          # chown root:root /etc/cron.weekly
+          # chmod og-rwx /etc/cron.weekly
+
+        scored: true
+
+      - id: 5.1.6
+        description: "Ensure permissions on /etc/cron.monthly are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.monthly"
+        tests:
+          test_items:
+            - flag: "700/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set ownership and permissions on `/etc/cron.monthly` :
+
+          # chown root:root /etc/cron.monthly
+          # chmod og-rwx /etc/cron.monthly
+
+        scored: true
+
+      - id: 5.1.7
+        description: "Ensure permissions on /etc/cron.d are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.d"
+        tests:
+          test_items:
+            - flag: "700/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set ownership and permissions on `/etc/cron.d` :
+
+          # chown root:root /etc/cron.d
+          # chmod og-rwx /etc/cron.d
+
+        scored: true
+
+      - id: 5.1.8.a
+        description: "Ensure at/cron is restricted to authorized users"
+        audit: "stat /etc/cron.deny"
+        tests:
+          test_items:
+            - flag: "stat: cannot stat '/etc/cron.deny': No such file or directory"
+              set: true
+        remediation: |
+          Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
+
+          # rm /etc/cron.deny
+          # rm /etc/at.deny
+          # touch /etc/cron.allow
+          # touch /etc/at.allow
+          # chmod og-rwx /etc/cron.allow
+          # chmod og-rwx /etc/at.allow
+          # chown root:root /etc/cron.allow
+          # chown root:root /etc/at.allow
+
+        scored: true
+
+      - id: 5.1.8.b
+        description: "Ensure at/cron is restricted to authorized users"
+        audit: "stat /etc/at.deny"
+        tests:
+          test_items:
+            - flag: "stat: cannot stat '/etc/at.deny': No such file or directory"
+              set: true
+        remediation: |
+          Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
+
+          # rm /etc/cron.deny
+          # rm /etc/at.deny
+          # touch /etc/cron.allow
+          # touch /etc/at.allow
+          # chmod og-rwx /etc/cron.allow
+          # chmod og-rwx /etc/at.allow
+          # chown root:root /etc/cron.allow
+          # chown root:root /etc/at.allow
+
+        scored: true
+
+      - id: 5.1.8.c
+        description: "Ensure at/cron is restricted to authorized users"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.allow"
+        tests:
+          test_items:
+            - flag: "600/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
+
+          # rm /etc/cron.deny
+          # rm /etc/at.deny
+          # touch /etc/cron.allow
+          # touch /etc/at.allow
+          # chmod og-rwx /etc/cron.allow
+          # chmod og-rwx /etc/at.allow
+          # chown root:root /etc/cron.allow
+          # chown root:root /etc/at.allow
+
+        scored: true
+
+      - id: 5.1.8.d
+        description: "Ensure at/cron is restricted to authorized users"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/at.allow"
+        tests:
+          test_items:
+            - flag: "600/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
+
+          # rm /etc/cron.deny
+          # rm /etc/at.deny
+          # touch /etc/cron.allow
+          # touch /etc/at.allow
+          # chmod og-rwx /etc/cron.allow
+          # chmod og-rwx /etc/at.allow
+          # chown root:root /etc/cron.allow
+          # chown root:root /etc/at.allow
+
+        scored: true
+
+  - id: 5.2
+    description: "SSH Server Configuration"
+    checks:
+      - id: 5.2.1
+        description: "Ensure permissions on /etc/ssh/sshd_config are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/ssh/sshd_config"
+        tests:
+          test_items:
+            - flag: "600/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following commands to set ownership and permissions on `/etc/ssh/sshd_config`:
+
+          # chown root:root /etc/ssh/sshd_config
+          # chmod og-rwx /etc/ssh/sshd_config
+
+        scored: true
+
+      - id: 5.2.2
+        description: "Ensure permissions on SSH private host key files are configured"
+        audit: "find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec stat {} \\;"
+        type: manual
+        remediation: |
+          Run the following commands to set ownership and permissions on the private SSH host key files
+          # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chown root:root {} \;
+          # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod 0600 {} \;
+
+        scored: true
+      - id: 5.2.3
+        description: "Ensure permissions on SSH public host key files are configured"
+        audit: "find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec stat {} \\;"
+        type: manual
+        remediation: |
+          Run the following commands to set permissions and ownership on the SSH host public key files
+          # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chmod 0644 {} \;
+          #find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chown root:root {} \;
+
+        scored: true
+      - id: 5.2.4
+        description: "Ensure SSH Protocol is set to 2"
+        audit: "grep ^Protocol /etc/ssh/sshd_config"
+        tests:
+          test_items:
+            - flag: "Protocol 2"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          Protocol 2
+
+        scored: true
+      - id: 5.2.5
+        description: "Ensure SSH LogLevel is set to INFO"
+        audit: "grep ^LogLevel /etc/ssh/sshd_config"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "LogLevel VERBOSE"
+              set: true
+            - flag: "LogLevel INFO"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+          LogLevel VERBOSE
+          OR
+          LogLevel INFO
+        scored: true
+
+      - id: 5.2.6
+        description: "Ensure SSH X11 forwarding is disabled"
+        audit: "grep ^X11Forwarding /etc/ssh/sshd_config"
+        tests:
+          test_items:
+            - flag: "X11Forwarding no"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          X11Forwarding no
+
+        scored: true
+
+      - id: 5.2.7
+        description: "Ensure SSH MaxAuthTries is set to 4 or less"
+        audit: "sshd -T | grep maxauthtries"
+        tests:
+          test_items:
+            - flag: "maxauthtries"
+              compare:
+                op: lte
+                value: "4"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          MaxAuthTries 4
+
+        scored: true
+
+      - id: 5.2.8
+        description: "Ensure SSH IgnoreRhosts is enabled"
+        audit: "sshd -T | grep ignorerhosts"
+        tests:
+          test_items:
+            - flag: "ignorerhosts yes"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          IgnoreRhosts yes
+
+        scored: true
+
+      - id: 5.2.9
+        description: "Ensure SSH HostbasedAuthentication is disabled"
+        audit: "sshd -T | grep hostbasedauthentication"
+        tests:
+          test_items:
+            - flag: "hostbasedauthentication no"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          hostbasedauthentication no
+
+        scored: true
+
+      - id: 5.2.10
+        description: "Ensure SSH root login is disabled"
+        audit: "sshd -T | grep permitrootlogin"
+        tests:
+          test_items:
+            - flag: "permitrootlogin no"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          permitrootlogin no
+
+        scored: true
+
+      - id: 5.2.11
+        description: "Ensure SSH PermitEmptyPasswords is disabled"
+        audit: "sshd -T | grep permitemptypasswords"
+        tests:
+          test_items:
+            - flag: "permitemptypasswords no"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          permitemptypasswords no
+
+        scored: true
+
+      - id: 5.2.12
+        description: "Ensure SSH PermitUserEnvironment is disabled"
+        audit: "sshd -T | grep permituserenvironment"
+        tests:
+          test_items:
+            - flag: "permituserenvironment no"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          permituserenvironment no
+
+        scored: true
+
+      - id: 5.2.13
+        description: "Ensure only approved MAC algorithms are used"
+        audit: "sshd -T | grep ciphers"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "3des-cbc"
+              set: false
+            - flag: "aes128-cbc"
+              set: false
+            - flag: "aes192-cbc"
+              set: false
+            - flag: "aes256-cbc"
+              set: false
+            - flag: "arcfour"
+              set: false
+            - flag: "arcfour128"
+              set: false
+            - flag: "arcfour256"
+              set: false
+            - flag: "blowfish-cbc"
+              set: false
+            - flag: "cast128-cbc"
+              set: false
+            - flag: "rijndael-cbc@lysator.liu.se"
+              set: false
+        remediation: |
+          Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma
+          separated list of the site approved ciphers
+          Example:
+          Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+        scored: true
+
+      - id: 5.2.14
+        description: "Ensure only strong MAC algorithms are used"
+        audit: 'sshd -T | grep -i "MACs"'
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "hmac-md5"
+              set: false
+            - flag: "hmac-md5-96"
+              set: false
+            - flag: "hmac-ripemd160"
+              set: false
+            - flag: "hmac-sha1"
+              set: false
+            - flag: "hmac-sha1-96"
+              set: false
+            - flag: "umac-64@openssh.com"
+              set: false
+            - flag: "umac-128@openssh.com"
+              set: false
+            - flag: "hmac-md5-etm@openssh.com"
+              set: false
+            - flag: "hmac-md5-96-etm@openssh.com"
+              set: false
+            - flag: "hmac-ripemd160-etm@openssh.com"
+              set: false
+            - flag: "hmac-sha1-etm@openssh.com"
+              set: false
+            - flag: "hmac-sha1-96-etm@openssh.com"
+              set: false
+            - flag: "umac-64-etm@openssh.com"
+              set: false
+            - flag: "umac-128-etm@openssh.com"
+              set: false
+
+        remediation: |
+          Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma
+          separated list of the site approved MACs
+          Example:
+          MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+        scored: true
+      - id: 5.2.15
+        description: "Ensure only strong Key Exchange algorithms are used"
+        audit: "sshd -T | grep kexalgorithms"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "diffie-hellman-group1-sha1"
+              set: false
+            - flag: "diffie-hellman-group14-sha1"
+              set: false
+            - flag: "diffie-hellman-group-exchange-sha1"
+              set: false
+        remediation: |
+          Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma
+          separated list of the site approved key exchange algorithms
+          Example:
+          KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-
+          group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-
+          sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-
+          hellman-group-exchange-sha256
+
+        scored: true
+      - id: 5.2.16.a
+        description: "Ensure SSH Idle Timeout Interval is configured"
+        audit: "sshd -T | grep clientaliveinterval"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "clientaliveinterval"
+              compare:
+                op: lte
+                value: "300"
+              set: true
+            - flag: "clientaliveinterval"
+              compare:
+                op: gte
+                value: "1"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameters according to site policy:
+
+          clientaliveinterval 300
+          clientalivecountmax 0
+
+        scored: true
+
+      - id: 5.2.16.b
+        description: "Ensure SSH Idle Timeout Interval is configured"
+        audit: "sshd -T | grep clientalivecountmax"
+        tests:
+          test_items:
+            - flag: "clientalivecountmax"
+              compare:
+                op: lte
+                value: "3"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameters according to site policy:
+
+          clientaliveinterval 300
+          clientalivecountmax 0
+
+        scored: true
+
+      - id: 5.2.17
+        description: "Ensure SSH LoginGraceTime is set to one minute or less"
+        audit: "sshd -T | grep logingracetime"
+        tests:
+          test_items:
+            - flag: "logingracetime"
+              compare:
+                op: lte
+                value: "60"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          logingracetime 60
+
+        scored: true
+
+      - id: 5.2.18.a
+        description: "Ensure SSH access is limited"
+        audit: "sshd -T | grep allowusers"
+        type: manual
+        tests:
+          test_items:
+            - flag: "AllowUsers <userlist>"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
+
+          AllowUsers
+          AllowGroups
+          DenyUsers
+          DenyGroups
+
+        scored: true
+
+      - id: 5.2.18.b
+        description: "Ensure SSH access is limited"
+        audit: "sshd -T | grep allowgroups"
+        type: manual
+        tests:
+          test_items:
+            - flag: "AllowGroups <grouplist>"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
+
+          AllowUsers
+          AllowGroups
+          DenyUsers
+          DenyGroups
+
+        scored: true
+
+      - id: 5.2.18.c
+        description: "Ensure SSH access is limited"
+        audit: "sshd -T | grep denyusers"
+        type: manual
+        tests:
+          test_items:
+            - flag: "DenyUsers <userlist>"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
+
+          AllowUsers
+          AllowGroups
+          DenyUsers
+          DenyGroups
+
+        scored: true
+
+      - id: 5.2.18.d
+        description: "Ensure SSH access is limited"
+        audit: "sshd -T | grep denygroups"
+        type: manual
+        tests:
+          test_items:
+            - flag: "DenyGroups <grouplist>"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
+
+          AllowUsers
+          AllowGroups
+          DenyUsers
+          DenyGroups
+
+        scored: true
+
+      - id: 5.2.19
+        description: "Ensure SSH warning banner is configured"
+        audit: "sshd -T | grep banner"
+        tests:
+          test_items:
+            - flag: "banner /etc/issue.net"
+              set: true
+        remediation: |
+          Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
+
+          banner /etc/issue.net
+
+        scored: true
+      - id: 5.2.20
+        description: "Ensure SSH PAM is enabled"
+        audit: "sshd -T | grep -i usepam"
+        tests:
+          test_items:
+            - flag: "usepam yes"
+              set: true
+        remediation: |
+          Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+          UsePAM yes
+        scored: true
+      - id: 5.2.21
+        description: "Ensure SSH AllowTcpForwarding is disabled"
+        audit: "sshd -T | grep -i allowtcpforwarding"
+        tests:
+          test_items:
+            - flag: "allowtcpforwarding no"
+              set: true
+        remediation: |
+          Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+          allowtcpforwarding no
+        scored: true
+      - id: 5.2.22
+        description: "Ensure SSH MaxStartups is configured"
+        audit: "sshd -T | grep -i maxstartups"
+        type: manual
+        remediation: |
+          Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+          maxstartups 10:30:60
+        scored: true
+      - id: 5.2.23
+        description: "Ensure SSH MaxSessions is set to 4 or less"
+        audit: "sshd -T | grep -i maxsessions"
+        tests:
+          test_items:
+            - flag: "maxsessions"
+              compare:
+                op: lte
+                value: "4"
+              set: true
+        remediation: |
+          Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+          MaxSessions 4
+        scored: true
+
+  - id: 5.3
+    description: "Configure PAM"
+    checks:
+      - id: 5.3.1
+        description: "Ensure password creation requirements are configured"
+        audit: "cat /etc/pam.d/common-password; cat /etc/pam.d/system-auth"
+        type: manual
+        remediation: |
+          Set password creation requirements to conform to site policy. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_cracklib.so` or `pam_pwquality.so` lines to include the required options:
+
+          password required pam_cracklib.so try_first_pass retry=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1
+          password requisite pam_pwquality.so try_first_pass retry=3
+
+          If `pam_pwquality.so` is in use also configure settings in `/etc/security/pwquality.conf` :
+
+          minlen = 14
+          dcredit = -1
+          ucredit = -1
+          ocredit = -1
+          lcredit = -1
+
+        scored: true
+
+      - id: 5.3.2
+        description: "Ensure lockout for failed password attempts is configured"
+        audit: "cat /etc/pam.d/system-auth; cat /etc/pam.d/password-auth; cat /etc/pam.d/common-auth"
+        type: manual
+        remediation: |
+          Set password lockouts to conform to site policy. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_tally2.so` or `pam_faillock.so` lines as appropriate:
+
+          auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900
+
+
+          auth required pam_faillock.so preauth audit silent deny=5 unlock_time=900
+          auth sufficient pam_unix.so
+          auth [default=die] pam_faillock.so authfail audit deny=5 unlock_time=900
+          auth sufficient pam_faillock.so authsucc audit deny=5 unlock_time=900
+
+        scored: false
+
+      - id: 5.3.3
+        description: "Ensure password reuse is limited"
+        audit: "cat /etc/pam.d/common-password; cat /etc/pam.d/system-auth"
+        type: manual
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "password required pam_pwhistory.so remember=5"
+              set: true
+            - flag: "password sufficient pam_unix.so remember=5"
+              set: true
+        remediation: |
+          Set remembered password history to conform to site policy. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_pwhistory.so` or `pam_unix.so` lines to include the `remember` option:
+
+          password required pam_pwhistory.so remember=5
+          password sufficient pam_unix.so remember=5
+
+        scored: false
+
+      - id: 5.3.4
+        description: "Ensure password hashing algorithm is SHA-512"
+        audit: "grep -E ^[^#].*sha512 /etc/pam.d/common-password /etc/pam.d/system-auth /etc/pam.d/password-auth"
+        tests:
+          test_items:
+            - flag: "sha512"
+              set: true
+        remediation: |
+          Set password hashing algorithm to sha512. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_unix.so` lines to include the sha512 option:
+
+          password sufficient pam_unix.so sha512
+
+        scored: false
+
+  - id: 5.4
+    description: "User Accounts and Environment"
+  - id: 5.4.1
+    description: "Set Shadow Password Suite Parameters"
+    checks:
+      - id: 5.4.1.1.a
+        description: "Ensure password expiration is 365 days or less"
+        audit: "grep ^PASS_MAX_DAYS /etc/login.defs"
+        tests:
+          test_items:
+            - flag: "PASS_MAX_DAYS"
+              compare:
+                op: lte
+                value: "365"
+              set: true
+        remediation: |
+          Set the `PASS_MAX_DAYS` parameter to conform to site policy in `/etc/login.defs` :
+
+          PASS_MAX_DAYS 356
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --maxdays 356
+
+        scored: true
+
+      - id: 5.4.1.1.b
+        description: "Ensure password expiration is 365 days or less"
+        audit: "grep -E '^[^:]+:[^!*]' /etc/shadow | cut -d: -f1,5"
+        type: manual
+        tests:
+          test_items:
+            - flag: "<list of users>"
+              set: true
+        remediation: |
+          Set the `PASS_MAX_DAYS` parameter to conform to site policy in `/etc/login.defs` :
+
+          PASS_MAX_DAYS 365
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --maxdays 365
+
+        scored: true
+
+      - id: 5.4.1.2.a
+        description: "Ensure minimum days between password changes is 7 or more"
+        audit: "grep ^PASS_MIN_DAYS /etc/login.defs"
+        tests:
+          test_items:
+            - flag: "PASS_MIN_DAYS"
+              compare:
+                op: gte
+                value: "7"
+              set: true
+
+        remediation: |
+          Set the `PASS_MIN_DAYS` parameter to 7 in `/etc/login.defs` :
+
+          PASS_MIN_DAYS 7
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --mindays 7
+
+        scored: true
+
+      - id: 5.4.1.2.b
+        description: "Ensure minimum days between password changes is 7 or more"
+        audit: "grep -E ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1,4"
+        type: manual
+        tests:
+          test_items:
+            - flag: "<list of users>"
+              set: true
+        remediation: |
+          Set the `PASS_MIN_DAYS` parameter to 7 in `/etc/login.defs` :
+
+          PASS_MIN_DAYS 7
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --mindays 7
+
+        scored: true
+
+      - id: 5.4.1.3.a
+        description: "Ensure password expiration warning days is 7 or more"
+        audit: "grep ^PASS_WARN_AGE /etc/login.defs"
+        tests:
+          test_items:
+            - flag: "PASS_WARN_AGE"
+              compare:
+                op: gte
+                value: "7"
+              set: true
+        remediation: |
+          Set the `PASS_WARN_AGE` parameter to 7 in `/etc/login.defs` :
+
+          PASS_WARN_AGE 7
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --warndays 7
+
+        scored: true
+
+      - id: 5.4.1.3.b
+        description: "Ensure password expiration warning days is 7 or more"
+        audit: "grep -E ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1,6"
+        type: manual
+        tests:
+          test_items:
+            - flag: "<list of users>"
+              set: true
+        remediation: |
+          Set the `PASS_WARN_AGE` parameter to 7 in `/etc/login.defs` :
+
+          PASS_WARN_AGE 7
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --warndays 7
+
+        scored: true
+
+      - id: 5.4.1.4.a
+        description: "Ensure inactive password lock is 30 days or less"
+        audit: "useradd -D | grep INACTIVE"
+        tests:
+          test_items:
+            - flag: "INACTIVE"
+              compare:
+                op: lte
+                value: 30
+              set: true
+        remediation: |
+          Run the following command to set the default password inactivity period to 30 days:
+
+          # useradd -D -f 30
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --inactive 30
+
+        scored: true
+
+      - id: 5.4.1.4.b
+        description: "Ensure inactive password lock is 30 days or less"
+        audit: "grep -E ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1,7"
+        type: manual
+        tests:
+          test_items:
+            - flag: "<list of users>"
+              set: true
+        remediation: |
+          Run the following command to set the default password inactivity period to 30 days:
+
+          # useradd -D -f 30
+
+          Modify user parameters for all users with a password set to match:
+
+          # chage --inactive 30
+
+        scored: true
+      - id: 5.4.1.5
+        description: "Ensure all users last password change date is in the past"
+        audit: |
+          #!/bin/bash
+          for usr in $(cut -d: -f1 /etc/shadow | sort -u ); do
+                  p=$(chage --list $usr | grep '^Last password change' | cut -d: -f2)
+                  today=$(date +'%b %d %Y')
+                  if [ $(date --date="$p" +%s) -gt $(date --date="$today" +%s) ]; then
+                      echo "$usr : $p"
+                  fi
+                  done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Investigate any users with a password change date in the future and correct them. Locking the account, expiring the password, or resetting the password manually may be appropriate.
+        scored: true
+
+      - id: 5.4.2.a
+        description: "Ensure system accounts are non-login"
+        audit: "awk -F: '($1!=\"root\" && $1!=\"sync\" && $1!=\"shutdown\" && $1!=\"halt\" && $1!~/^\\+/ && $3<'\"$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs)\"' && $7!=\"'\"$(which nologin)\"'\" && $7!=\"/bin/false\") {print}' /etc/passwd"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Run the commands appropriate for your distribution:
+          Set the shell for any accounts returned by the audit to nologin:
+          # usermod -s $(which nologin) <user>
+          Lock any non root accounts returned by the audit:
+          # usermod -L <user>
+          The following command will set all system accounts to a non login shell:
+          awk -F: '($1!="root" && $1!="sync" && $1!="shutdown" && $1!="halt" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"' && $7!="'"$(which nologin)"'" && $7!="/bin/false") {print $1}' /etc/passwd | while read user do usermod -s $(which nologin) $user done
+          The following command will automatically lock not root system accounts:
+          awk -F: '($1!="root" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"') {print $1}' /etc/passwd | xargs -I '{}' passwd -S '{}' | awk '($2!="L" && $2!="LK") {print $1}' | while read user do usermod -L $user done
+
+        scored: true
+      - id: 5.4.2.b
+        description: "Ensure system accounts are non-login"
+        audit: "awk -F: '($1!=\"root\" && $1!~/^\\+/ && $3<'\"$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs)\"') {print $1}' /etc/passwd | xargs -I '{}' passwd -S '{}' | awk '($2!=\"L\" && $2!=\"LK\") {print $1}'"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Run the commands appropriate for your distribution:
+          Set the shell for any accounts returned by the audit to nologin:
+          # usermod -s $(which nologin) <user>
+          Lock any non root accounts returned by the audit:
+          # usermod -L <user>
+          The following command will set all system accounts to a non login shell:
+          awk -F: '($1!="root" && $1!="sync" && $1!="shutdown" && $1!="halt" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"' && $7!="'"$(which nologin)"'" && $7!="/bin/false") {print $1}' /etc/passwd | while read user do usermod -s $(which nologin) $user done
+          The following command will automatically lock not root system accounts:
+          awk -F: '($1!="root" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"') {print $1}' /etc/passwd | xargs -I '{}' passwd -S '{}' | awk '($2!="L" && $2!="LK") {print $1}' | while read user do usermod -L $user done
+
+        scored: true
+      - id: 5.4.3
+        description: "Ensure default group for the root account is GID 0"
+        audit: "grep ^root: /etc/passwd | cut -f4 -d:"
+        tests:
+          test_items:
+            - flag: "0"
+              set: true
+        remediation: |
+          Run the following command to set the `root` user default group to GID `0` :
+
+          # usermod -g 0 root
+
+        scored: true
+
+      - id: 5.4.4.a
+        description: "Ensure default user umask is 027 or more restrictive"
+        sub_checks:
+          - check:
+              audit: "grep umask /etc/bashrc"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "umask 027"
+                    set: true
+              remediation: |
+                Edit the `/etc/bashrc`, `/etc/profile` and `/etc/profile.d/*.sh` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
+
+                umask 027
+          - check:
+              audit: "grep umask /etc/bash.bashrc"
+              constraints:
+                platform:
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "umask 027"
+                    set: true
+              remediation: |
+                Edit the `/etc/bashrc`, `/etc/profile` and `/etc/profile.d/*.sh` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
+
+                umask 027
+        scored: true
+
+      - id: 5.4.4.b
+        description: "Ensure default user umask is 027 or more restrictive"
+        audit: "grep -h umask /etc/profile /etc/profile.d/*.sh"
+        tests:
+          test_items:
+            - flag: "umask 027"
+              set: true
+        remediation: |
+          Edit the `/etc/bashrc`, `/etc/profile` and `/etc/profile.d/*.sh` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
+
+          umask 027
+
+        scored: true
+      - id: 5.4.5.a
+        description: "Ensure default user shell timeout is 900 seconds or less"
+        sub_checks:
+          - check:
+              audit: "grep ^TMOUT /etc/bashrc"
+              constraints:
+                platform:
+                  - rhel7
+              tests:
+                test_items:
+                  - flag: "TMOUT"
+                    compare:
+                      op: lte
+                      value: "900"
+                    set: true
+            remediation: |
+              Edit the `/etc/bashrc` and `/etc/profile` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
+
+              TMOUT=600
+          - check:
+              audit: "grep ^TMOUT /etc/bash.bashrc"
+              constraints:
+                platform:
+                  - ubuntu16
+                  - ubuntu18
+              tests:
+                test_items:
+                  - flag: "TMOUT"
+                    compare:
+                      op: lte
+                      value: "900"
+                    set: true
+            remediation: |
+              Edit the `/etc/bashrc` and `/etc/profile` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
+
+              TMOUT=600
+
+        scored: true
+      - id: 5.4.5.b
+        description: "Ensure default user shell timeout is 900 seconds or less"
+        audit: "grep ^TMOUT /etc/profile"
+        tests:
+          test_items:
+            - flag: "TMOUT"
+              compare:
+                op: lte
+                value: "900"
+              set: true
+        remediation: |
+          Edit the `/etc/bashrc` and `/etc/profile` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
+
+          TMOUT=600
+
+        scored: true
+  - id: 5.5
+    description: "Set Shadow Password Suite Parameters"
+    checks:
+      - id: 5.5
+        description: "Ensure root login is restricted to system console"
+        audit: "cat /etc/securetty"
+        type: manual
+        remediation: |
+          Remove entries for any consoles that are not in a physically secure location.
+        scored: true
+
+      - id: 5.6.a
+        description: "Ensure access to the su command is restricted"
+        audit: "grep pam_wheel.so /etc/pam.d/su"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "auth"
+              set: true
+            - flag: "required"
+              set: true
+            - flag: "pam_wheel.so"
+              set: true
+            - flag: "use_uid"
+              set: true
+        remediation: |
+          Add the following line to the `/etc/pam.d/su` file:
+
+          auth required pam_wheel.so use_uid
+
+          Create a comma separated list of users in the wheel statement in the `/etc/group` file:
+
+          wheel:x:10:root,
+
+        scored: true
+
+      - id: 5.6.b
+        description: "Ensure access to the su command is restricted"
+        audit: "grep wheel /etc/group"
+        type: manual
+        tests:
+          test_items:
+            - flag: "wheel:x:10:root,<user list>"
+              set: true
+        remediation: |
+          Add the following line to the `/etc/pam.d/su` file:
+
+          auth required pam_wheel.so use_uid
+
+          Create a comma separated list of users in the wheel statement in the `/etc/group` file:
+
+          wheel:x:10:root,
+
+        scored: true
+
+  - id: 6
+    description: "System Maintenance"
+  - id: 6.1
+    description: "System File Permissions"
+    checks:
+      - id: 6.1.1
+        description: "Audit system file permissions"
+        sub_checks:
+          - check:
+              audit: "rpm -Va --nomtime --nosize --nomd5 --nolinkto > <filename>"
+              type: "manual"
+              constraints:
+                platform:
+                  - rhel7
+              remediation: |
+                Correct any discrepancies found and rerun the audit until output is clean or risk is mitigated or accepted.
+          - check:
+              audit: "dpkg --verify > <filename>"
+              type: "manual"
+              constraints:
+                platform:
+                  - ubuntu16
+              remediation: |
+                Correct any discrepancies found and rerun the audit until output is clean or risk is mitigated or accepted.
+          - check:
+              audit: "apt-get source > <filename>"
+              type: "manual"
+              constraints:
+                platform:
+                  - ubuntu18
+              remediation: |
+                Correct any discrepancies found and rerun the audit until output is clean or risk is mitigated or accepted.
+        scored: false
+      - id: 6.1.2
+        description: "Ensure permissions on /etc/passwd are configured"
+        audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/passwd"
+        tests:
+          test_items:
+            - flag: "644/Uid:root/0Gid:root/0"
+              set: true
+        remediation: |
+          Run the following command to set permissions on `/etc/passwd` :
+
+          # chown root:root /etc/passwd
+          # chmod 644 /etc/passwd
+
+        scored: true
+
+      - id: 6.1.3
+        description: "Ensure permissions on /etc/shadow are configured"
+        audit: 'stat -c "Uid:%U/%u Gid:%G permissions=%a" /etc/shadow'
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Uid:root/0"
+              set: true
+            - flag: "Gid"
+              compare:
+                op: regex
+                value: "shadow|root"
+              set: true
+            - flag: "permissions"
               compare:
                 op: bitmask
-                value: "0640"
-              set: true                        
-          remediation: |
-                Edit the `/etc/rsyslog.conf` and `/etc/rsyslog.d/*.conf` files and set `$FileCreateMode` to `0640` or more restrictive:
-                
-                $FileCreateMode 0640
-      scored: true
-    - id: 4.2.1.5
-      description: "Ensure rsyslog is configured to send logs to a remote log host"
-      sub_checks:
-      - check:
-          audit: 'grep "^*.*[^I][^I]*@" /etc/rsyslog.conf /etc/rsyslog.d/*.conf'   
-          constraints:          
-            syslog:
-            - rsyslog
-          type: manual                        
-          remediation: |
-                Edit the `/etc/rsyslog.conf` and `/etc/rsyslog.d/*.conf` files and add the following line (where `loghost.example.com` is the name of your central log host).
-                
-                *.* @@loghost.example.com
-                
-                Run the following command to reload the `rsyslogd` configuration:
-                
-                # pkill -HUP rsyslogd
-      scored: true
-    - id: 4.2.1.6.a
-      description: "Ensure remote rsyslog messages are only accepted on designated log hosts."
-      sub_checks:
-      - check:
-          audit: "grep ^\\$ModLoad /etc/rsyslog.conf /etc/rsyslog.d/*.conf"   
-          constraints:          
-            syslog:
-            - rsyslog
-          tests:
-            test_items:
-            - flag: "\\$ModLoad imtcp"
-              set: true                        
-          remediation: |
-                For hosts that are designated as log hosts, edit the `/etc/rsyslog.conf` file and un-comment or add the following lines:
-                
-                $ModLoad imtcp
-                $InputTCPServerRun 514
-                
-                For hosts that are not designated as log hosts, edit the `/etc/rsyslog.conf` file and comment or remove the following lines:
-                
-                # $ModLoad imtcp
-                # $InputTCPServerRun 514
-                
-                Run the following command to reload the `rsyslogd` configuration:
-                
-                # pkill -HUP rsyslogd
-                
-      scored: false   
-    - id: 4.2.1.6.b
-      description: "Ensure remote rsyslog messages are only accepted on designated log hosts."
-      sub_checks:
-      - check:
-          audit: "grep ^\\$InputTCPServerRun /etc/rsyslog.conf /etc/rsyslog.d/*.conf"  
-          constraints:          
-            syslog:
-            - rsyslog
-          tests:
-            test_items:
-            - flag: "\\$InputTCPServerRun 514"
-              set: true                        
-          remediation: |
-                For hosts that are designated as log hosts, edit the `/etc/rsyslog.conf` file and un-comment or add the following lines:
-                
-                $ModLoad imtcp
-                $InputTCPServerRun 514
-                
-                For hosts that are not designated as log hosts, edit the `/etc/rsyslog.conf` file and comment or remove the following lines:
-                
-                # $ModLoad imtcp
-                # $InputTCPServerRun 514
-                
-                Run the following command to reload the `rsyslogd` configuration:
-                
-                # pkill -HUP rsyslogd
-      scored: false   
-- id: 4.2.2
-  description: "Configure journald"
-  checks:
-    - id: 4.2.2.1
-      description: "Ensure journald is configured to send logs to rsyslog"
-      audit: "grep -e ForwardToSyslog /etc/systemd/journald.conf"   
-      tests:
-        test_items:
-        - flag: "ForwardToSyslog=yes"
-          set: true                        
-      remediation: |
-            Edit the /etc/systemd/journald.conf file and add the following line: 
-            ForwardToSyslog=yes
-            
-      scored: true 
-    - id: 4.2.2.2
-      description: "Ensure journald is configured to compress large log files (Scored)"
-      audit: "grep -e Compress /etc/systemd/journald.conf"   
-      tests:
-        test_items:
-        - flag: "Compress=yes"
-          set: true                        
-      remediation: |
-            Edit the /etc/systemd/journald.conf file and add the following line: 
-            Compress=yes
-            
-      scored: true 
-    - id: 4.2.2.3
-      description: "Ensure journald is configured to write logfiles to persistent disk"
-      audit: "grep -e Storage /etc/systemd/journald.conf"   
-      tests:
-        test_items:
-        - flag: "Storage=persistent"
-          set: true                        
-      remediation: |
-            Edit the /etc/systemd/journald.conf file and add the following line: 
-            Storage=persistent
-            
-      scored: true
-    - id: 4.2.3
-      description: "Ensure permissions on all logfiles are configured"
-      audit: "find /var/log -type f -ls"   
-      type: manual                        
-      remediation: |
-            Run the following commands to set permissions on all existing log files: 
-            find /var/log -type f -exec chmod g-wx,o-rwx "{}" + -o -type d -exec chmod g-w,o-rwx "{}" +    
-      scored: true
-    - id: 4.3
-      description: "Ensure logrotate is configured"
-      audit: "cat /etc/logrotate.conf; cat /etc/logrotate.d/* ;"
-      type: manual
-      remediation: |
-        Edit `/etc/logrotate.conf` and `/etc/logrotate.d/*` to ensure logs are rotated according to site policy.
-      scored: false
-- id: 5
-  description: "Access, Authentication and Authorization"
-- id: 5.1
-  description: "Configure cron"
-  checks:
-    - id: 5.1.1
-      description: "Ensure cron daemon is enabled"
-      sub_checks:
-      - check:
-          audit: "chkconfig --list crond"
-          constraints:          
-            platform:
-            - rhel6
-          tests:
-            test_items:
-            - flag: "2:on 3:on 4:on 5:on"
-              set: true                        
-          remediation: |
-                Based on your system configuration, run the appropriate one of the following commands to enable `cron` :
-                
-                # chkconfig crond on
-                
-                
-                # systemctl enable crond
-                
-                
-                # update-rc.d crond enable
-      - check:
-          audit: "systemctl is-enabled crond"
-          constraints:          
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: true                        
-          remediation: |
-                Based on your system configuration, run the appropriate one of the following commands to enable `cron` :
-                
-                # chkconfig crond on
-                
-                
-                # systemctl enable crond
-                
-                
-                # update-rc.d crond enable
-      - check:
-          audit: "systemctl is-enabled cron"
-          constraints:          
-            platform:
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "enabled"
-              set: true                        
-          remediation: |
-                Based on your system configuration, run the appropriate one of the following commands to enable `cron` :
-                
-                # chkconfig cron on
-                
-                
-                # systemctl enable cron
-                
-                
-                # update-rc.d cron enable
-      scored: true                  
-    - id: 5.1.2
-      description: "Ensure permissions on /etc/crontab are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/crontab"   
-      tests:
-        test_items:
-        - flag: "600/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set ownership and permissions on `/etc/crontab` :
-            
-            # chown root:root /etc/crontab
-            # chmod og-rwx /etc/crontab
-            
-      scored: true                  
-                      
-            
-    - id: 5.1.3
-      description: "Ensure permissions on /etc/cron.hourly are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.hourly"   
-      tests:
-        test_items:
-        - flag: "700/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set ownership and permissions on `/etc/cron.hourly` :
-            
-            # chown root:root /etc/cron.hourly
-            # chmod og-rwx /etc/cron.hourly
-            
-      scored: true                  
-               
-            
-    - id: 5.1.4
-      description: "Ensure permissions on /etc/cron.daily are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.daily"   
-      tests:
-        test_items:
-        - flag: "700/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set ownership and permissions on `/etc/cron.daily` :
-            
-            # chown root:root /etc/cron.daily
-            # chmod og-rwx /etc/cron.daily
-            
-      scored: true                  
-                           
-            
-    - id: 5.1.5
-      description: "Ensure permissions on /etc/cron.weekly are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.weekly"   
-      tests:
-        test_items:
-        - flag: "700/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set ownership and permissions on `/etc/cron.weekly` :
-            
-            # chown root:root /etc/cron.weekly
-            # chmod og-rwx /etc/cron.weekly
-            
-      scored: true                  
-              
-            
-    - id: 5.1.6
-      description: "Ensure permissions on /etc/cron.monthly are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.monthly"   
-      tests:
-        test_items:
-        - flag: "700/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set ownership and permissions on `/etc/cron.monthly` :
-            
-            # chown root:root /etc/cron.monthly
-            # chmod og-rwx /etc/cron.monthly
-            
-      scored: true                  
-                             
-            
-    - id: 5.1.7
-      description: "Ensure permissions on /etc/cron.d are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.d"   
-      tests:
-        test_items:
-        - flag: "700/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set ownership and permissions on `/etc/cron.d` :
-            
-            # chown root:root /etc/cron.d
-            # chmod og-rwx /etc/cron.d
-            
-      scored: true                  
-                             
-            
-    - id: 5.1.8.a
-      description: "Ensure at/cron is restricted to authorized users"
-      audit: "stat /etc/cron.deny"   
-      tests:
-        test_items:
-        - flag: "stat: cannot stat '/etc/cron.deny': No such file or directory"
-          set: true                      
-      remediation: |
-            Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
-            
-            # rm /etc/cron.deny
-            # rm /etc/at.deny
-            # touch /etc/cron.allow
-            # touch /etc/at.allow
-            # chmod og-rwx /etc/cron.allow
-            # chmod og-rwx /etc/at.allow
-            # chown root:root /etc/cron.allow
-            # chown root:root /etc/at.allow
-            
-      scored: true                  
-            
-    - id: 5.1.8.b
-      description: "Ensure at/cron is restricted to authorized users"
-      audit: "stat /etc/at.deny"   
-      tests:
-        test_items:
-        - flag: "stat: cannot stat '/etc/at.deny': No such file or directory"
-          set: true                        
-      remediation: |
-            Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
-            
-            # rm /etc/cron.deny
-            # rm /etc/at.deny
-            # touch /etc/cron.allow
-            # touch /etc/at.allow
-            # chmod og-rwx /etc/cron.allow
-            # chmod og-rwx /etc/at.allow
-            # chown root:root /etc/cron.allow
-            # chown root:root /etc/at.allow
-            
-      scored: true                  
-            
-    - id: 5.1.8.c
-      description: "Ensure at/cron is restricted to authorized users"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/cron.allow"   
-      tests:
-        test_items:
-        - flag: "600/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
-            
-            # rm /etc/cron.deny
-            # rm /etc/at.deny
-            # touch /etc/cron.allow
-            # touch /etc/at.allow
-            # chmod og-rwx /etc/cron.allow
-            # chmod og-rwx /etc/at.allow
-            # chown root:root /etc/cron.allow
-            # chown root:root /etc/at.allow
-            
-      scored: true                  
-            
-    - id: 5.1.8.d
-      description: "Ensure at/cron is restricted to authorized users"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/at.allow"   
-      tests:
-        test_items:
-        - flag: "600/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to remove `/etc/cron.deny` and `/etc/at.deny` and create and set permissions and ownership for `/etc/cron.allow` and `/etc/at.allow` :
-            
-            # rm /etc/cron.deny
-            # rm /etc/at.deny
-            # touch /etc/cron.allow
-            # touch /etc/at.allow
-            # chmod og-rwx /etc/cron.allow
-            # chmod og-rwx /etc/at.allow
-            # chown root:root /etc/cron.allow
-            # chown root:root /etc/at.allow
-            
-      scored: true                  
-            
-- id: 5.2
-  description: "SSH Server Configuration"
-  checks:
-    - id: 5.2.1
-      description: "Ensure permissions on /etc/ssh/sshd_config are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/ssh/sshd_config"   
-      tests:
-        test_items:
-        - flag: "600/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following commands to set ownership and permissions on `/etc/ssh/sshd_config`:
-            
-            # chown root:root /etc/ssh/sshd_config
-            # chmod og-rwx /etc/ssh/sshd_config
-            
-      scored: true                  
-                           
-            
-    - id: 5.2.2
-      description: "Ensure permissions on SSH private host key files are configured"
-      audit: "find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec stat {} \\;"   
-      type: manual                       
-      remediation: |
-            Run the following commands to set ownership and permissions on the private SSH host key files 
-            # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chown root:root {} \; 
-            # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod 0600 {} \;
-            
-      scored: true
-    - id: 5.2.3
-      description: "Ensure permissions on SSH public host key files are configured"
-      audit: "find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec stat {} \\;"   
-      type: manual                       
-      remediation: |
-            Run the following commands to set permissions and ownership on the SSH host public key files 
-            # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chmod 0644 {} \; 
-            #find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chown root:root {} \;
-            
-      scored: true
-    - id: 5.2.4
-      description: "Ensure SSH Protocol is set to 2"
-      audit: "grep ^Protocol /etc/ssh/sshd_config"   
-      tests:
-        test_items:
-        - flag: "Protocol 2"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            Protocol 2
-            
-      scored: true
-    - id: 5.2.5
-      description: "Ensure SSH LogLevel is set to INFO"
-      audit: "grep ^LogLevel /etc/ssh/sshd_config"   
-      tests:
-        bin_op: or
-        test_items:
-        - flag: "LogLevel VERBOSE"
-          set: true   
-        - flag: "LogLevel INFO"
-          set: true          
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            LogLevel VERBOSE
-            OR 
-            LogLevel INFO
-      scored: true                  
-                       
-            
-    - id: 5.2.6
-      description: "Ensure SSH X11 forwarding is disabled"
-      audit: "grep ^X11Forwarding /etc/ssh/sshd_config"   
-      tests:
-        test_items:
-        - flag: "X11Forwarding no"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            X11Forwarding no
-            
-      scored: true                  
-            
-                 
-            
-    - id: 5.2.7
-      description: "Ensure SSH MaxAuthTries is set to 4 or less"
-      audit: "sshd -T | grep maxauthtries"   
-      tests:
-        test_items:
-        - flag: "maxauthtries"
-          compare:
-            op: lte
-            value: "4"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            MaxAuthTries 4
-            
-      scored: true                  
-
-    - id: 5.2.8
-      description: "Ensure SSH IgnoreRhosts is enabled"
-      audit: "sshd -T | grep ignorerhosts"   
-      tests:
-        test_items:
-        - flag: "ignorerhosts yes"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            IgnoreRhosts yes
-            
-      scored: true                  
-            
-
-    - id: 5.2.9
-      description: "Ensure SSH HostbasedAuthentication is disabled"
-      audit: "sshd -T | grep hostbasedauthentication"   
-      tests:
-        test_items:
-        - flag: "hostbasedauthentication no"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            hostbasedauthentication no
-            
-      scored: true                  
-                         
-            
-    - id: 5.2.10
-      description: "Ensure SSH root login is disabled"
-      audit: "sshd -T | grep permitrootlogin"   
-      tests:
-        test_items:
-        - flag: "permitrootlogin no"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            permitrootlogin no
-            
-      scored: true                  
-            
-                 
-            
-    - id: 5.2.11
-      description: "Ensure SSH PermitEmptyPasswords is disabled"
-      audit: "sshd -T | grep permitemptypasswords"   
-      tests:
-        test_items:
-        - flag: "permitemptypasswords no"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            permitemptypasswords no
-            
-      scored: true                  
-            
-    - id: 5.2.12
-      description: "Ensure SSH PermitUserEnvironment is disabled"
-      audit: "sshd -T | grep permituserenvironment"   
-      tests:
-        test_items:
-        - flag: "permituserenvironment no"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            permituserenvironment no
-            
-      scored: true                  
-                            
-            
-    - id: 5.2.13
-      description: "Ensure only approved MAC algorithms are used"
-      audit: "sshd -T | grep ciphers"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "3des-cbc"
-          set: false   
-        - flag: "aes128-cbc"
-          set: false
-        - flag: "aes192-cbc"
-          set: false   
-        - flag: "aes256-cbc"
-          set: false
-        - flag: "arcfour"
-          set: false   
-        - flag: "arcfour128"
-          set: false
-        - flag: "arcfour256"
-          set: false   
-        - flag: "blowfish-cbc"
-          set: false
-        - flag: "cast128-cbc"
-          set: false   
-        - flag: "rijndael-cbc@lysator.liu.se"
-          set: false
-      remediation: |
-            Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma 
-            separated list of the site approved ciphers 
-            Example: 
-            Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-      scored: true                  
-                  
-            
-    - id: 5.2.14
-      description: "Ensure only strong MAC algorithms are used"
-      audit: "sshd -T | grep -i \"MACs\""   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "hmac-md5"
-          set: false   
-        - flag: "hmac-md5-96"
-          set: false
-        - flag: "hmac-ripemd160"
-          set: false   
-        - flag: "hmac-sha1"
-          set: false
-        - flag: "hmac-sha1-96"
-          set: false   
-        - flag: "umac-64@openssh.com"
-          set: false
-        - flag: "umac-128@openssh.com"
-          set: false   
-        - flag: "hmac-md5-etm@openssh.com"
-          set: false
-        - flag: "hmac-md5-96-etm@openssh.com"
-          set: false   
-        - flag: "hmac-ripemd160-etm@openssh.com"
-          set: false
-        - flag: "hmac-sha1-etm@openssh.com"
-          set: false   
-        - flag: "hmac-sha1-96-etm@openssh.com"
-          set: false
-        - flag: "umac-64-etm@openssh.com"
-          set: false   
-        - flag: "umac-128-etm@openssh.com"
-          set: false
-          
-      remediation: |
-            Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma 
-            separated list of the site approved MACs 
-            Example: 
-            MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
-      scored: true
-    - id: 5.2.15
-      description: "Ensure only strong Key Exchange algorithms are used"
-      audit: "sshd -T | grep kexalgorithms"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "diffie-hellman-group1-sha1"
-          set: false   
-        - flag: "diffie-hellman-group14-sha1"
-          set: false
-        - flag: "diffie-hellman-group-exchange-sha1"
-          set: false   
-      remediation: |
-            Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma 
-            separated list of the site approved key exchange algorithms 
-            Example: 
-            KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-
-            group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-
-            sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-
-            hellman-group-exchange-sha256
-            
-      scored: true 
-    - id: 5.2.16.a
-      description: "Ensure SSH Idle Timeout Interval is configured"
-      audit: "sshd -T | grep clientaliveinterval"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "clientaliveinterval"
-          compare:
-            op: lte
-            value: "300"
-          set: true 
-        - flag: "clientaliveinterval"
-          compare:
-            op: gte
-            value: "1"
-          set: true
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameters according to site policy:
-            
-            clientaliveinterval 300
-            clientalivecountmax 0
-            
-      scored: true                  
-            
-    - id: 5.2.16.b
-      description: "Ensure SSH Idle Timeout Interval is configured"
-      audit: "sshd -T | grep clientalivecountmax"   
-      tests:
-        test_items:
-        - flag: "clientalivecountmax"
-          compare:
-            op: lte
-            value: "3"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameters according to site policy:
-            
-            clientaliveinterval 300
-            clientalivecountmax 0
-            
-      scored: true                  
-            
-    - id: 5.2.17
-      description: "Ensure SSH LoginGraceTime is set to one minute or less"
-      audit: "sshd -T | grep logingracetime"   
-      tests:
-        test_items:
-        - flag: "logingracetime"
-          compare:
-            op: lte
-            value: "60"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            logingracetime 60
-            
-      scored: true                  
-               
-            
-    - id: 5.2.18.a
-      description: "Ensure SSH access is limited"
-      audit: "sshd -T | grep allowusers"   
-      type: manual
-      tests:
-        test_items:
-        - flag: "AllowUsers <userlist>"
-          set: true                     
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
-            
-            AllowUsers 
-            AllowGroups 
-            DenyUsers 
-            DenyGroups 
-            
-      scored: true                  
-            
-    - id: 5.2.18.b
-      description: "Ensure SSH access is limited"
-      audit: "sshd -T | grep allowgroups"   
-      type: manual
-      tests:
-        test_items:
-        - flag: "AllowGroups <grouplist>"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
-            
-            AllowUsers 
-            AllowGroups 
-            DenyUsers 
-            DenyGroups 
-            
-      scored: true                  
-            
-    - id: 5.2.18.c
-      description: "Ensure SSH access is limited"
-      audit: "sshd -T | grep denyusers"   
-      type: manual
-      tests:
-        test_items:
-        - flag: "DenyUsers <userlist>"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
-            
-            AllowUsers 
-            AllowGroups 
-            DenyUsers 
-            DenyGroups 
-            
-      scored: true                  
-            
-    - id: 5.2.18.d
-      description: "Ensure SSH access is limited"
-      audit: "sshd -T | grep denygroups"  
-      type: manual
-      tests:
-        test_items:
-        - flag: "DenyGroups <grouplist>"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set one or more of the parameter as follows:
-            
-            AllowUsers 
-            AllowGroups 
-            DenyUsers 
-            DenyGroups 
-            
-      scored: true                  
-            
-    - id: 5.2.19
-      description: "Ensure SSH warning banner is configured"
-      audit: "sshd -T | grep banner"   
-      tests:
-        test_items:
-        - flag: "banner /etc/issue.net"
-          set: true                        
-      remediation: |
-            Edit the `/etc/ssh/sshd_config` file to set the parameter as follows:
-            
-            banner /etc/issue.net
-            
-      scored: true                  
-    - id: 5.2.20
-      description: "Ensure SSH PAM is enabled"
-      audit: "sshd -T | grep -i usepam"   
-      tests:
-        test_items:
-        - flag: "usepam yes"
-          set: true                        
-      remediation: |
-            Edit the /etc/ssh/sshd_config file to set the parameter as follows: 
-            UsePAM yes
-      scored: true          
-    - id: 5.2.21
-      description: "Ensure SSH AllowTcpForwarding is disabled"
-      audit: "sshd -T | grep -i allowtcpforwarding"   
-      tests:
-        test_items:
-        - flag: "allowtcpforwarding no"
-          set: true                        
-      remediation: |
-            Edit the /etc/ssh/sshd_config file to set the parameter as follows: 
-            allowtcpforwarding no
-      scored: true 
-    - id: 5.2.22
-      description: "Ensure SSH MaxStartups is configured"
-      audit: "sshd -T | grep -i maxstartups"   
-      type: manual                       
-      remediation: |
-            Edit the /etc/ssh/sshd_config file to set the parameter as follows: 
-            maxstartups 10:30:60
-      scored: true
-    - id: 5.2.23
-      description: "Ensure SSH MaxSessions is set to 4 or less"
-      audit: "sshd -T | grep -i maxsessions"   
-      tests:
-        test_items:
-        - flag: "maxsessions"
-          compare:
-            op: lte
-            value: "4"
-          set: true                        
-      remediation: |
-            Edit the /etc/ssh/sshd_config file to set the parameter as follows: 
-            MaxSessions 4
-      scored: true 
-
-            
-- id: 5.3
-  description: "Configure PAM"
-  checks:
-    - id: 5.3.1
-      description: "Ensure password creation requirements are configured"
-      audit: "cat /etc/pam.d/common-password; cat /etc/pam.d/system-auth"   
-      type: manual
-      remediation: |
-            Set password creation requirements to conform to site policy. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_cracklib.so` or `pam_pwquality.so` lines to include the required options:
-            
-            password required pam_cracklib.so try_first_pass retry=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1
-            password requisite pam_pwquality.so try_first_pass retry=3
-            
-            If `pam_pwquality.so` is in use also configure settings in `/etc/security/pwquality.conf` :
-            
-            minlen = 14
-            dcredit = -1
-            ucredit = -1
-            ocredit = -1
-            lcredit = -1
-            
-      scored: true                  
-            
-    - id: 5.3.2
-      description: "Ensure lockout for failed password attempts is configured"
-      audit: "cat /etc/pam.d/system-auth; cat /etc/pam.d/password-auth; cat /etc/pam.d/common-auth"   
-      type: manual            
-      remediation: |
-            Set password lockouts to conform to site policy. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_tally2.so` or `pam_faillock.so` lines as appropriate:
-            
-            auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900
-            
-            
-            auth required pam_faillock.so preauth audit silent deny=5 unlock_time=900
-            auth sufficient pam_unix.so
-            auth [default=die] pam_faillock.so authfail audit deny=5 unlock_time=900
-            auth sufficient pam_faillock.so authsucc audit deny=5 unlock_time=900
-            
-      scored: false                  
-            
-    - id: 5.3.3
-      description: "Ensure password reuse is limited"
-      audit: "cat /etc/pam.d/common-password; cat /etc/pam.d/system-auth" 
-      type: manual
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "password required pam_pwhistory.so remember=5"
-          set: true
-        - flag: "password sufficient pam_unix.so remember=5"
-          set: true
-      remediation: |
-            Set remembered password history to conform to site policy. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_pwhistory.so` or `pam_unix.so` lines to include the `remember` option:
-            
-            password required pam_pwhistory.so remember=5
-            password sufficient pam_unix.so remember=5
-            
-      scored: false                  
-            
-    - id: 5.3.4
-      description: "Ensure password hashing algorithm is SHA-512"
-      audit: "grep -E ^[^#].*sha512 /etc/pam.d/common-password /etc/pam.d/system-auth /etc/pam.d/password-auth"   
-      tests:
-        test_items:
-        - flag: "sha512"
-          set: true                                  
-      remediation: |
-            Set password hashing algorithm to sha512. Many distributions provide tools for updating PAM configuration, consult your documentation for details. If no tooling is provided edit the appropriate `/etc/pam.d/` configuration file and add or modify the `pam_unix.so` lines to include the sha512 option:
-            
-            password sufficient pam_unix.so sha512
-            
-      scored: false                  
-            
-- id: 5.4
-  description: "User Accounts and Environment"
-- id: 5.4.1
-  description: "Set Shadow Password Suite Parameters"
-  checks:
-    - id: 5.4.1.1.a
-      description: "Ensure password expiration is 365 days or less"
-      audit: "grep ^PASS_MAX_DAYS /etc/login.defs"
-      tests:
-        test_items:
-        - flag: "PASS_MAX_DAYS"
-          compare:
-            op: lte
-            value: "365"
-          set: true  
-      remediation: |
-        Set the `PASS_MAX_DAYS` parameter to conform to site policy in `/etc/login.defs` :
-
-        PASS_MAX_DAYS 356
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --maxdays 356
-
-      scored: true
-
-    - id: 5.4.1.1.b
-      description: "Ensure password expiration is 365 days or less"
-      audit: "grep -E '^[^:]+:[^!*]' /etc/shadow | cut -d: -f1,5"
-      type: manual
-      tests:
-        test_items:
-        - flag: "<list of users>"
-          set: true
-      remediation: |
-        Set the `PASS_MAX_DAYS` parameter to conform to site policy in `/etc/login.defs` :
-
-        PASS_MAX_DAYS 365
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --maxdays 365
-
-      scored: true
-
-    - id: 5.4.1.2.a
-      description: "Ensure minimum days between password changes is 7 or more"
-      audit: "grep ^PASS_MIN_DAYS /etc/login.defs"
-      tests:
-        test_items:
-        - flag: "PASS_MIN_DAYS"
-          compare:
-            op: gte
-            value: "7"
-          set: true
-        
-      remediation: |
-        Set the `PASS_MIN_DAYS` parameter to 7 in `/etc/login.defs` :
-
-        PASS_MIN_DAYS 7
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --mindays 7
-
-      scored: true
-
-    - id: 5.4.1.2.b
-      description: "Ensure minimum days between password changes is 7 or more"
-      audit: "grep -E ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1,4"
-      type: manual
-      tests:
-        test_items:
-        - flag: "<list of users>"
-          set: true
-      remediation: |
-        Set the `PASS_MIN_DAYS` parameter to 7 in `/etc/login.defs` :
-
-        PASS_MIN_DAYS 7
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --mindays 7
-
-      scored: true
-
-    - id: 5.4.1.3.a
-      description: "Ensure password expiration warning days is 7 or more"
-      audit: "grep ^PASS_WARN_AGE /etc/login.defs"
-      tests:
-        test_items:
-        - flag: "PASS_WARN_AGE"
-          compare:
-            op: gte
-            value: "7"
-          set: true
-      remediation: |
-        Set the `PASS_WARN_AGE` parameter to 7 in `/etc/login.defs` :
-
-        PASS_WARN_AGE 7
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --warndays 7
-
-      scored: true
-
-    - id: 5.4.1.3.b
-      description: "Ensure password expiration warning days is 7 or more"
-      audit: "grep -E ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1,6"
-      type: manual
-      tests:
-        test_items:
-        - flag: "<list of users>"
-          set: true
-      remediation: |
-        Set the `PASS_WARN_AGE` parameter to 7 in `/etc/login.defs` :
-
-        PASS_WARN_AGE 7
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --warndays 7
-
-      scored: true
-
-    - id: 5.4.1.4.a
-      description: "Ensure inactive password lock is 30 days or less"
-      audit: "useradd -D | grep INACTIVE"
-      tests:
-        test_items:
-        - flag: "INACTIVE"
-          compare:
-            op: lte
-            value: 30
-          set: true
-      remediation: |
-        Run the following command to set the default password inactivity period to 30 days:
-
-        # useradd -D -f 30
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --inactive 30
-
-      scored: true
-
-    - id: 5.4.1.4.b
-      description: "Ensure inactive password lock is 30 days or less"
-      audit: "grep -E ^[^:]+:[^\\!*] /etc/shadow | cut -d: -f1,7"
-      type: manual
-      tests:
-        test_items:
-        - flag: "<list of users>"
-          set: true
-      remediation: |
-        Run the following command to set the default password inactivity period to 30 days:
-
-        # useradd -D -f 30
-
-        Modify user parameters for all users with a password set to match:
-
-        # chage --inactive 30
-
-      scored: true
-    - id: 5.4.1.5
-      description: "Ensure all users last password change date is in the past"
-      audit: |
-            #!/bin/bash 
-            for usr in $(cut -d: -f1 /etc/shadow | sort -u ); do
-                    p=$(chage --list $usr | grep '^Last password change' | cut -d: -f2)
-                    today=$(date +'%b %d %Y')
-                    if [ $(date --date="$p" +%s) -gt $(date --date="$today" +%s) ]; then
-                        echo "$usr : $p"
-                    fi
-                    done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true
-      remediation: |
-        Investigate any users with a password change date in the future and correct them. Locking the account, expiring the password, or resetting the password manually may be appropriate.
-      scored: true
-
-    - id: 5.4.2.a
-      description: "Ensure system accounts are non-login"
-      audit: "awk -F: '($1!=\"root\" && $1!=\"sync\" && $1!=\"shutdown\" && $1!=\"halt\" && $1!~/^\\+/ && $3<'\"$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs)\"' && $7!=\"'\"$(which nologin)\"'\" && $7!=\"/bin/false\") {print}' /etc/passwd"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Run the commands appropriate for your distribution: 
-            Set the shell for any accounts returned by the audit to nologin:
-            # usermod -s $(which nologin) <user>
-            Lock any non root accounts returned by the audit: 
-            # usermod -L <user>
-            The following command will set all system accounts to a non login shell: 
-            awk -F: '($1!="root" && $1!="sync" && $1!="shutdown" && $1!="halt" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"' && $7!="'"$(which nologin)"'" && $7!="/bin/false") {print $1}' /etc/passwd | while read user do usermod -s $(which nologin) $user done
-            The following command will automatically lock not root system accounts: 
-            awk -F: '($1!="root" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"') {print $1}' /etc/passwd | xargs -I '{}' passwd -S '{}' | awk '($2!="L" && $2!="LK") {print $1}' | while read user do usermod -L $user done
-            
-      scored: true                  
-    - id: 5.4.2.b
-      description: "Ensure system accounts are non-login"
-      audit: "awk -F: '($1!=\"root\" && $1!~/^\\+/ && $3<'\"$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs)\"') {print $1}' /etc/passwd | xargs -I '{}' passwd -S '{}' | awk '($2!=\"L\" && $2!=\"LK\") {print $1}'"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                                  
-      remediation: |
-            Run the commands appropriate for your distribution: 
-            Set the shell for any accounts returned by the audit to nologin:
-            # usermod -s $(which nologin) <user>
-            Lock any non root accounts returned by the audit: 
-            # usermod -L <user>
-            The following command will set all system accounts to a non login shell: 
-            awk -F: '($1!="root" && $1!="sync" && $1!="shutdown" && $1!="halt" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"' && $7!="'"$(which nologin)"'" && $7!="/bin/false") {print $1}' /etc/passwd | while read user do usermod -s $(which nologin) $user done
-            The following command will automatically lock not root system accounts: 
-            awk -F: '($1!="root" && $1!~/^\+/ && $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"') {print $1}' /etc/passwd | xargs -I '{}' passwd -S '{}' | awk '($2!="L" && $2!="LK") {print $1}' | while read user do usermod -L $user done
-            
-      scored: true   
-    - id: 5.4.3
-      description: "Ensure default group for the root account is GID 0"
-      audit: "grep ^root: /etc/passwd | cut -f4 -d:"   
-      tests:
-        test_items:
-        - flag: "0"
-          set: true                        
-      remediation: |
-            Run the following command to set the `root` user default group to GID `0` :
-            
-            # usermod -g 0 root
-            
-      scored: true                  
-                         
-            
-    - id: 5.4.4.a
-      description: "Ensure default user umask is 027 or more restrictive"
-      sub_checks: 
-      - check:
-          audit: "grep umask /etc/bashrc" 
-          constraints:
-            platform:
-            - rhel7
-          tests:
-            test_items:
-            - flag: "umask 027"
-              set: true                        
-          remediation: |
-                Edit the `/etc/bashrc`, `/etc/profile` and `/etc/profile.d/*.sh` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
-                
-                umask 027
-      - check:
-          audit: "grep umask /etc/bash.bashrc" 
-          constraints:
-            platform:
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "umask 027"
-              set: true                        
-          remediation: |
-                Edit the `/etc/bashrc`, `/etc/profile` and `/etc/profile.d/*.sh` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
-                
-                umask 027
-      scored: true                  
-            
-    - id: 5.4.4.b
-      description: "Ensure default user umask is 027 or more restrictive"
-      audit: "grep -h umask /etc/profile /etc/profile.d/*.sh"   
-      tests:
-        test_items:
-        - flag: "umask 027"
-          set: true                        
-      remediation: |
-            Edit the `/etc/bashrc`, `/etc/profile` and `/etc/profile.d/*.sh` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
-            
-            umask 027
-            
-      scored: true                  
-    - id: 5.4.5.a
-      description: "Ensure default user shell timeout is 900 seconds or less"
-      sub_checks:
-      - check:
-          audit: "grep ^TMOUT /etc/bashrc"
-          constraints:
-            platform: 
-            - rhel7
-          tests:
-            test_items:
-            - flag: "TMOUT"
-              compare:
-                op: lte
-                value: "900"
-              set: true                        
+                value: "640"
+              set: true
         remediation: |
-              Edit the `/etc/bashrc` and `/etc/profile` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
-            
-              TMOUT=600                  
-      - check:
-          audit: "grep ^TMOUT /etc/bash.bashrc"
-          constraints:
-            platform: 
-            - ubuntu16
-            - ubuntu18
-          tests:
-            test_items:
-            - flag: "TMOUT"
-              compare:
-                op: lte
-                value: "900"
-              set: true                        
+          Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/shadow` :
+
+          # chown root:root /etc/shadow
+          # chown root:shadow /etc/shadow
+          # chmod o-rwx,g-wx /etc/shadow
+
+        scored: true
+
+      - id: 6.1.4
+        description: "Ensure permissions on /etc/group are configured"
+        audit: 'stat -c "Uid:%U/%u Gid:%G/%g permissions=%a" /etc/group'
+        tests:
+          test_items:
+            - flag: "Uid:root/0 Gid:root/0 permissions=644"
+              set: true
         remediation: |
-              Edit the `/etc/bashrc` and `/etc/profile` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
-            
-              TMOUT=600
-            
-      scored: true      
-    - id: 5.4.5.b
-      description: "Ensure default user shell timeout is 900 seconds or less"
-      audit: "grep ^TMOUT /etc/profile"   
-      tests:
-        test_items:
-        - flag: "TMOUT"
-          compare:
-            op: lte
-            value: "900"
-          set: true                        
-      remediation: |
-            Edit the `/etc/bashrc` and `/etc/profile` files (and the appropriate files for any other shell supported on your system) and add or edit any umask parameters as follows:
-            
-            TMOUT=600
-            
-      scored: true
-- id: 5.5
-  description: "Set Shadow Password Suite Parameters"
-  checks:
-    - id: 5.5
-      description: "Ensure root login is restricted to system console"
-      audit: "cat /etc/securetty"
-      type: manual
-      remediation: |
-        Remove entries for any consoles that are not in a physically secure location.
-      scored: true
+          Run the following command to set permissions on `/etc/group` :
 
-    - id: 5.6.a
-      description: "Ensure access to the su command is restricted"
-      audit: "grep pam_wheel.so /etc/pam.d/su"
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "auth"
-          set: true
-        - flag: "required"
-          set: true
-        - flag: "pam_wheel.so"
-          set: true
-        - flag: "use_uid"
-          set: true
-      remediation: |
-        Add the following line to the `/etc/pam.d/su` file:
+          # chown root:root /etc/group
+          # chmod 644 /etc/group
 
-        auth required pam_wheel.so use_uid
+        scored: true
 
-        Create a comma separated list of users in the wheel statement in the `/etc/group` file:
+      - id: 6.1.5
+        description: "Ensure permissions on /etc/gshadow are configured"
+        audit: 'stat -c "Uid:%U/%u Gid:%G permissions=%a" /etc/gshadow'
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Uid:root/0"
+              set: true
+            - flag: "Gid"
+              compare:
+                op: regex
+                value: "shadow|root"
+              set: true
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "640"
+              set: true
+        remediation: |
+          Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/gshadow` :
 
-        wheel:x:10:root,
+          # chown root:root /etc/gshadow
+          # chown root:shadow /etc/gshadow
+          # chmod o-rwx,g-rw /etc/gshadow
 
-      scored: true
+        scored: true
 
-    - id: 5.6.b
-      description: "Ensure access to the su command is restricted"
-      audit: "grep wheel /etc/group"
-      type: manual
-      tests:
-        test_items:
-        - flag: "wheel:x:10:root,<user list>"
-          set: true
-      remediation: |
-        Add the following line to the `/etc/pam.d/su` file:
+      - id: 6.1.6
+        description: "Ensure permissions on /etc/passwd- are configured"
+        audit: 'stat -c "Uid:%U/%u Gid:%G/%g permissions=%a" /etc/passwd-'
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Uid:root/0 Gid:root/0"
+              set: true
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+              set: true
+        remediation: |
+          Run the following command to set permissions on `/etc/passwd-` :
 
-        auth required pam_wheel.so use_uid
+          # chown root:root /etc/passwd-
+          # chmod u-x,go-rwx /etc/passwd-
 
-        Create a comma separated list of users in the wheel statement in the `/etc/group` file:
+        scored: true
 
-        wheel:x:10:root,
+      - id: 6.1.7
+        description: "Ensure permissions on /etc/shadow- are configured"
+        audit: 'stat -c "Uid:%U/%u Gid:%G permissions=%a" /etc/shadow-'
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Uid:root/0"
+              set: true
+            - flag: "Gid"
+              compare:
+                op: regex
+                value: "shadow|root"
+              set: true
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "640"
+              set: true
+        remediation: |
+          Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/shadow-` :
 
-      scored: true
+          # chown root:root /etc/shadow-
+          # chown root:shadow /etc/shadow-
+          # chmod o-rwx,g-rw /etc/shadow-
 
-- id: 6
-  description: "System Maintenance"
-- id: 6.1
-  description: "System File Permissions"
-  checks:
-    - id: 6.1.1
-      description: "Audit system file permissions"
-      sub_checks:
-      - check:
-          audit: "rpm -Va --nomtime --nosize --nomd5 --nolinkto > <filename>"
-          type: "manual"            
-          constraints:
-            platform:
-            - rhel7
-          remediation: |
-                Correct any discrepancies found and rerun the audit until output is clean or risk is mitigated or accepted.
-      - check:
-          audit: "dpkg --verify > <filename>"
-          type: "manual"      
-          constraints:
-            platform:
-            - ubuntu16
-          remediation: |
-                Correct any discrepancies found and rerun the audit until output is clean or risk is mitigated or accepted.
-      - check:
-          audit: "apt-get source > <filename>"
-          type: "manual"      
-          constraints:
-            platform:
-            - ubuntu18
-          remediation: |
-                Correct any discrepancies found and rerun the audit until output is clean or risk is mitigated or accepted.
-      scored: false
-    - id: 6.1.2
-      description: "Ensure permissions on /etc/passwd are configured"
-      audit: "stat -c %a/Uid:%U/%uGid:%G/%g /etc/passwd"   
-      tests:
-        test_items:
-        - flag: "644/Uid:root/0Gid:root/0"
-          set: true                        
-      remediation: |
-            Run the following command to set permissions on `/etc/passwd` :
-            
-            # chown root:root /etc/passwd
-            # chmod 644 /etc/passwd
-            
-      scored: true                  
-            
-            
-    - id: 6.1.3
-      description: "Ensure permissions on /etc/shadow are configured"
-      audit: "stat -c \"Uid:%U/%u Gid:%G permissions=%a\" /etc/shadow"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Uid:root/0"
-          set: true                        
-        - flag: "Gid"
-          compare:
-            op: regex
-            value: 'shadow|root'
-          set: true  
-        - flag: "permissions"
-          compare:
-            op: bitmask
-            value: "640"
-          set: true
-      remediation: |
-            Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/shadow` :
-            
-            # chown root:root /etc/shadow
-            # chown root:shadow /etc/shadow
-            # chmod o-rwx,g-wx /etc/shadow
-            
-      scored: true                  
-                    
-            
-    - id: 6.1.4
-      description: "Ensure permissions on /etc/group are configured"
-      audit: "stat -c \"Uid:%U/%u Gid:%G/%g permissions=%a\" /etc/group"   
-      tests:
-        test_items:
-        - flag: "Uid:root/0 Gid:root/0 permissions=644"
-          set: true                        
-      remediation: |
-            Run the following command to set permissions on `/etc/group` :
-            
-            # chown root:root /etc/group
-            # chmod 644 /etc/group
-            
-      scored: true                  
-                    
-            
-    - id: 6.1.5
-      description: "Ensure permissions on /etc/gshadow are configured"
-      audit: "stat -c \"Uid:%U/%u Gid:%G permissions=%a\" /etc/gshadow"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Uid:root/0"
-          set: true                        
-        - flag: "Gid"
-          compare:
-            op: regex
-            value: 'shadow|root'
-          set: true  
-        - flag: "permissions"
-          compare:
-            op: bitmask
-            value: "640"
-          set: true  
-      remediation: |
-            Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/gshadow` :
-            
-            # chown root:root /etc/gshadow
-            # chown root:shadow /etc/gshadow
-            # chmod o-rwx,g-rw /etc/gshadow
-            
-      scored: true                                      
-            
-    - id: 6.1.6
-      description: "Ensure permissions on /etc/passwd- are configured"
-      audit: "stat -c \"Uid:%U/%u Gid:%G/%g permissions=%a\" /etc/passwd-"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Uid:root/0 Gid:root/0"
-          set: true
-        - flag: "permissions"
-          compare:
-            op: bitmask
-            value: "600"
-          set: true                    
-      remediation: |
-            Run the following command to set permissions on `/etc/passwd-` :
-            
-            # chown root:root /etc/passwd-
-            # chmod u-x,go-rwx /etc/passwd-
-            
-      scored: true                  
-            
-            
-    - id: 6.1.7
-      description: "Ensure permissions on /etc/shadow- are configured"
-      audit: "stat -c \"Uid:%U/%u Gid:%G permissions=%a\" /etc/shadow-"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Uid:root/0"
-          set: true                        
-        - flag: "Gid"
-          compare:
-            op: regex
-            value: 'shadow|root'
-          set: true  
-        - flag: "permissions"
-          compare:
-            op: bitmask
-            value: "640"
-          set: true 
-      remediation: |
-            Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/shadow-` :
-            
-            # chown root:root /etc/shadow-
-            # chown root:shadow /etc/shadow-
-            # chmod o-rwx,g-rw /etc/shadow-
-            
-      scored: true                  
-                          
-            
-    - id: 6.1.8
-      description: "Ensure permissions on /etc/group- are configured"
-      audit: "stat -c \"Uid:%U/%u Gid:%G/%g permissions=%a\" /etc/group-"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Uid:root/0 Gid:root/0"
-          set: true
-        - flag: "permissions"
-          compare:
-            op: bitmask
-            value: "644"
-          set: true
-      remediation: |
-            Run the following command to set permissions on `/etc/group-` :
-            
-            # chown root:root /etc/group-
-            # chmod u-x,go-wx /etc/group-
-            
-      scored: true                  
-                    
-            
-    - id: 6.1.9
-      description: "Ensure permissions on /etc/gshadow- are configured"
-      audit: "stat -c \"Uid:%U/%u Gid:%G permissions=%a\" /etc/gshadow-"   
-      tests:
-        bin_op: and
-        test_items:
-        - flag: "Uid:root/0"
-          set: true                        
-        - flag: "Gid"
-          compare:
-            op: regex
-            value: 'shadow|root'
-          set: true  
-        - flag: "permissions"
-          compare:
-            op: bitmask
-            value: "640"
-          set: true 
-      remediation: |
-            Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/gshadow-` :
-            
-            # chown root:root /etc/gshadow-
-            # chown root:shadow /etc/gshadow-
-            # chmod o-rwx,g-rw /etc/gshadow-
-            
-      scored: true                  
-                          
-            
-    - id: 6.1.10.a
-      description: "Ensure no world writable files exist"
-      audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002 | head -n 100"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Removing write access for the "other" category ( `chmod o-w ` ) is advisable, but always consult relevant vendor documentation to avoid breaking any application dependencies on a given file.
-      scored: true                  
-            
-    - id: 6.1.10.b
-      description: "Ensure no world writable files exist"
-      audit: "find <partition> -xdev -type f -perm -0002 "   
-      type: manual                        
-      remediation: |
-            Removing write access for the "other" category ( `chmod o-w ` ) is advisable, but always consult relevant vendor documentation to avoid breaking any application dependencies on a given file.
-      scored: true     
+        scored: true
 
-    - id: 6.1.11.a
-      description: "Ensure no unowned files or directories exist"
-      audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser | head -n 100"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
-      scored: true                  
-            
-    - id: 6.1.11.b
-      description: "Ensure no unowned files or directories exist"
-      audit: "find <partition> -xdev -type f -perm -0002"   
-      type: manual
-      remediation: |
-            Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
-      scored: true                  
-            
-    - id: 6.1.12.a
-      description: "Ensure no ungrouped files or directories exist"
-      audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup | head -n 100"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
-      scored: true                  
-            
-    - id: 6.1.12.b
-      description: "Ensure no ungrouped files or directories exist"
-      audit: "find <partition> -xdev -nogroup"   
-      type: manual                        
-      remediation: |
-            Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
-      scored: true                  
-            
-    - id: 6.1.13.a
-      description: "Audit SUID executables"
-      audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -4000 | head -n 100"   
-      type: manual
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Ensure that no rogue SUID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
-      scored: false                  
-            
-    - id: 6.1.13.b
-      description: "Audit SUID executables"
-      audit: "find <partition> -xdev -type f -perm -4000"   
-      type: manual                        
-      remediation: |
-            Ensure that no rogue SUID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
-      scored: false                  
-            
-    - id: 6.1.14.a
-      description: "Audit SGID executables"
-      audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -2000 | head -n 100"   
-      type: manual 
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Ensure that no rogue SGID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
-      scored: false                  
-            
-    - id: 6.1.14.b
-      description: "Audit SGID executables"
-      audit: "find <partition> -xdev -type f -perm -2000"   
-      type: manual                        
-      remediation: |
-            Ensure that no rogue SGID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
-      scored: false                  
-            
-- id: 6.2
-  description: "User and Group Settings"
-  checks:
-    - id: 6.2.1
-      description: "Ensure password fields are not empty"
-      audit: "awk -F: '($2 == \"\" ) { print $1 \" does not have a password \"}' /etc/shadow"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-           If any accounts in the /etc/shadow file do not have a password, run the following command 
-           to lock the account until it can be determined why it does not have a password: 
-           # passwd -l <username>
-           Also, check to see if the account is logged in and investigate what it is being used for to 
-           determine if it needs to be forced off.
-      scored: true                  
-                   
-    - id: 6.2.2
-      description: "Ensure no legacy \"+\" entries exist in /etc/passwd"
-      audit: "grep '^\\+:' /etc/passwd"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Remove any legacy '+' entries from `/etc/passwd` if they exist.
-      scored: true                  
-                            
-            
-    - id: 6.2.3
-      description: "Ensure no legacy \"+\" entries exist in /etc/shadow"
-      audit: "grep '^\\+:' /etc/shadow"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Remove any legacy '+' entries from `/etc/shadow` if they exist.
-      scored: true                  
-                     
-            
-    - id: 6.2.4
-      description: "Ensure no legacy \"+\" entries exist in /etc/group"
-      audit: "grep '^\\+:' /etc/group"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Remove any legacy '+' entries from `/etc/group` if they exist.
-      scored: true                  
-                       
-            
-    - id: 6.2.5
-      description: "Ensure root is the only UID 0 account"
-      audit: "awk -F: '($3 == 0) { print $1 }' /etc/passwd"   
-      tests:
-        test_items:
-        - flag: "root"
-          set: true                        
-      remediation: |
-            Remove any users other than `root` with UID `0` or assign them a new UID if appropriate.
-      scored: true                  
-            
-    - id: 6.2.6
-      description: "Ensure root PATH Integrity"
-      audit: |
-            #!/bin/bash
-            if [ "$(echo "$PATH" | grep ::)" != "" ]; then
-                    echo "Empty Directory in PATH (::)"
-            fi
+      - id: 6.1.8
+        description: "Ensure permissions on /etc/group- are configured"
+        audit: 'stat -c "Uid:%U/%u Gid:%G/%g permissions=%a" /etc/group-'
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Uid:root/0 Gid:root/0"
+              set: true
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+              set: true
+        remediation: |
+          Run the following command to set permissions on `/etc/group-` :
 
-            if [ "$(echo "$PATH" | grep :$)" != "" ]; then
-                    echo "Trailing : in PATH"
-            fi
+          # chown root:root /etc/group-
+          # chmod u-x,go-wx /etc/group-
 
-            p=$(echo "$PATH" | sed -e 's/::/:/' -e 's/:$//' -e 's/:/ /g')
-            set -- $p
-            while [ "$1" != "" ]; do
-                    if [ "$1" = "." ]; then
-                            shift
-                            continue
-                    fi
-                    if [ -d "$1" ]; then
-                            dirperm=$(ls -ldH "$1" | cut -f1 -d" ")
-                            if [ "$(echo "$dirperm" | cut -c6)" != "-" ]; then
-                                    echo "Group Write permission set on directory $1"
-                            fi
-                            if [ "$(echo "$dirperm" | cut -c9)" != "-" ]; then
-                                    echo "Other Write permission set on directory $1"
-                            fi
-                            dirown=$(ls -ldH "$1" | awk '{print $3}')
-                            if [ "$dirown" != "root" ] ; then
-                                    echo "$1 is not owned by root"
-                            fi
-                    else
-                            echo "$1 is not a directory"
-                    fi
-                    shift
-            done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Correct or justify any items discovered in the Audit step.
-      scored: true                  
-            
-      
-    - id: 6.2.7
-      description: "Ensure all users' home directories exist"
-      audit: |
-            #!/bin/bash
-            grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' |
-                    while read -r user dir; do
-                            if [ ! -d "$dir" ]; then
-                                    echo "The home directory ($dir) of user $user does not exist."
-                            fi
-                    done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            If any users' home directories do not exist, create them and make sure the respective user owns the directory. Users without an assigned home directory should be removed or assigned a home directory as appropriate.
-      scored: true                                          
-            
-    - id: 6.2.8
-      description: "Ensure users' home directories permissions are 750 or more restrictive"
-      audit: |
-            #!/bin/bash 
-            grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | 
-            while read user dir; do 
-                if [ ! -d "$dir" ]; then 
-                    echo "The home directory ($dir) of user $user does not exist." 
-                else 
-                    dirperm=$(ls -ld $dir | cut -f1 -d" ") 
-                    if [ $(echo $dirperm | cut -c6) != "-" ]; then 
-                        echo "Group Write permission set on the home directory ($dir) of user $user" 
-                    fi 
-                    if [ $(echo $dirperm | cut -c8) != "-" ]; then 
-                        echo "Other Read permission set on the home directory ($dir) of user $user" 
-                    fi 
-                    if [ $(echo $dirperm | cut -c9) != "-" ]; then 
-                        echo "Other Write permission set on the home directory ($dir) of user $user" 
-                    fi 
-                    if [ $(echo $dirperm | cut -c10) != "-" ]; then 
-                        echo "Other Execute permission set on the home directory ($dir) of user $user" 
-                    fi 
-                fi 
-            done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Making global modifications to user home directories without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user file permissions and determine the action to be taken in accordance with site policy.
-      scored: true                              
-            
-    - id: 6.2.9
-      description: "Ensure users own their home directories"
-      audit: |
-            #!/bin/bash
-            grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
-                    if [ ! -d "$dir" ]; then
-                            echo "The home directory ($dir) of user $user does not exist."
-                    else
-                    owner=$(stat -L -c "%U" "$dir")
-                            if [ "$owner" != "$user" ]; then
-                            echo "The home directory ($dir) of user $user is owned by $owner."
-                            fi
-                    fi
-            done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Change the ownership of any home directories that are not owned by the defined user to the correct user.
-      scored: true                  
-                    
-            
-    - id: 6.2.10
-      description: "Ensure users' dot files are not group or world writable"
-      audit: |
-            #!/bin/bash
-            grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
-                    if [ ! -d "$dir" ]; then
-                            echo "The home directory ($dir) of user $user does not exist."
-                    else
-                            for file in $dir/.[A-Za-z0-9]*; do
-                                    if [ ! -h "$file" -a -f "$file" ]; then
-                                            fileperm=$(ls -ld $file | cut -f1 -d" ")
-                                                    if [ $(echo $fileperm | cut -c6) != "-" ]; then
-                                                            echo "Group Write permission set on file $file"
-                                                    fi
-                                                    if [ $(echo $fileperm | cut -c9) != "-" ]; then
-                                                            echo "Other Write permission set on file $file"
-                                            fi
-                                    fi
-                            done
-                    fi
-            done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user dot file permissions and determine the action to be taken in accordance with site policy.
-      scored: true                  
-      
-    - id: 6.2.11
-      description: "Ensure no users have .forward files"
-      audit: |
-            #!/bin/bash
-            grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
-                    if [ ! -d "$dir" ]; then
-                            echo "The home directory ($dir) of user $user does not exist."
-                    else
-                            if [ ! -h "$dir/.forward" -a -f "$dir/.forward" ]; then
-                                    echo ".forward file $dir/.forward exists"
-                            fi
-                    fi
-            done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.forward` files and determine the action to be taken in accordance with site policy.
-      scored: true                  
-                    
-            
-    - id: 6.2.12
-      description: "Ensure no users have .netrc files"
-      audit: |
-            #!/bin/bash
-            grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
-                    if [ ! -d "$dir" ]; then
-                            echo "The home directory ($dir) of user $user does not exist."
-                    else
-                            if [ ! -h "$dir/.netrc" -a -f "$dir/.netrc" ]; then
-                                    echo ".netrc file $dir/.netrc exists"
-                            fi
-                    fi
-            done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.netrc` files and determine the action to be taken in accordance with site policy.
-      scored: true                          
-            
-    - id: 6.2.13
-      description: "Ensure users' .netrc Files are not group or world accessible"
-      audit: |
-            #!/bin/bash
-            grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
-            if [ ! -d "$dir" ]; then
-                    echo "The home directory ($dir) of user $user does not exist."
-            else
-                    for file in $dir/.netrc; do
-                            if [ ! -h "$file" -a -f "$file" ]; then
-                                    fileperm=$(ls -ld $file | cut -f1 -d" ")
-                                    if [ $(echo $fileperm | cut -c5) != "-" ]; then
-                                            echo "Group Read set on $file"
-                                    fi
-                                    if [ $(echo $fileperm | cut -c6) != "-" ]; then
-                                            echo "Group Write set on $file"
-                                    fi
-                                    if [ $(echo $fileperm | cut -c7) != "-" ]; then
-                                            echo "Group Execute set on $file"
-                                    fi
-                                    if [ $(echo $fileperm | cut -c8) != "-" ]; then
-                                            echo "Other Read set on $file"
-                                    fi
-                                    if [ $(echo $fileperm | cut -c9) != "-" ]; then
-                                            echo "Other Write set on $file"
-                                    fi
-                                    if [ $(echo $fileperm | cut -c10) != "-" ]; then
-                                            echo "Other Execute set on $file"
-                                    fi
-                            fi
-                    done
-            fi
-            done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.netrc` file permissions and determine the action to be taken in accordance with site policy.
-      scored: true                  
-                                                                                                                    
-    - id: 6.2.14
-      description: "Ensure no users have .rhosts files"
-      audit: |
-            #!/bin/bash
-            grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
-            if [ ! -d "$dir" ]; then
-                    echo "The home directory ($dir) of user $user does not exist."
-            else
-                    for file in $dir/.rhosts; do
-                            if [ ! -h "$file" -a -f "$file" ]; then
-                                    echo ".rhosts file in $dir"
-                            fi
-                    done
-            fi
-            done
+        scored: true
 
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.rhosts` files and determine the action to be taken in accordance with site policy.
-      scored: true                  
-        
-    - id: 6.2.15
-      description: "Ensure all groups in /etc/passwd exist in /etc/group"
-      audit: |
-            #!/bin/bash
-            for i in $(cut -s -d: -f4 /etc/passwd | sort -u ); do
-                    grep -q -P "^.*?:[^:]*:$i:" /etc/group
-                    if [ $? -ne 0 ]; then
-                            echo "Group $i is referenced by /etc/passwd but does not exist in /etc/group"
-                    fi
-            done
+      - id: 6.1.9
+        description: "Ensure permissions on /etc/gshadow- are configured"
+        audit: 'stat -c "Uid:%U/%u Gid:%G permissions=%a" /etc/gshadow-'
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "Uid:root/0"
+              set: true
+            - flag: "Gid"
+              compare:
+                op: regex
+                value: "shadow|root"
+              set: true
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "640"
+              set: true
+        remediation: |
+          Run the one of the following chown commands as appropriate and the chmod to set permissions on `/etc/gshadow-` :
 
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Analyze the output of the Audit step above and perform the appropriate action to correct any discrepancies found.
-      scored: true                  
-           
-    - id: 6.2.16
-      description: "Ensure no duplicate UIDs exist"      
-      audit: |
-            #!/bin/bash
-            cut -f3 -d":" /etc/passwd | sort -n | uniq -c | while read x ; do
-                    [ -z "$x" ] && break
-                    set - $x
-                    if [ $1 -gt 1 ]; then
-                            users=$(awk -F: '($3 == n) { print $1 }' n=$2 /etc/passwd | xargs)
-                            echo "Duplicate UID ($2): $users"
-                    fi
-                    done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Based on the results of the audit script, establish unique UIDs and review all files owned by the shared UIDs to determine which UID they are supposed to belong to.
-      scored: true                                        
-            
-    - id: 6.2.17
-      description: "Ensure no duplicate GIDs exist"      
-      audit: |
-            #!/bin/bash
-            cut -f3 -d":" /etc/group | sort -n | uniq -c | while read x ; do
-            [ -z "$x" ] && break
-            set - $x
-            if [ $1 -gt 1 ]; then
-                    groups=$(awk -F: '($3 == n) { print $1 }' n=$2 /etc/group | xargs)
-                    echo "Duplicate GID ($2): $groups"
-            fi
-            done
+          # chown root:root /etc/gshadow-
+          # chown root:shadow /etc/gshadow-
+          # chmod o-rwx,g-rw /etc/gshadow-
 
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Based on the results of the audit script, establish unique GIDs and review all files owned by the shared GID to determine which group they are supposed to belong to.
-      scored: true                  
-            
-    - id: 6.2.18
-      description: "Ensure no duplicate user names exist"      
-      audit: |
-            #!/bin/bash
-            cut -f1 -d":" /etc/passwd | sort -n | uniq -c | while read x ; do
-                    [ -z "$x" ] && break
-                    set - $x
-                    if [ $1 -gt 1 ]; then
-                            uids=$(awk -F: '($1 == n) { print $3 }' n=$2 /etc/passwd | xargs)
-                            echo "Duplicate User Name ($2): $uids"
-                    fi
-                    done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Based on the results of the audit script, establish unique user names for the users. File ownerships will automatically reflect the change as long as the users have unique UIDs.
-      scored: true                  
-                          
-            
-    - id: 6.2.19
-      description: "Ensure no duplicate group names exist"      
-      audit: |
-            #!/bin/bash
-            cut -f1 -d":" /etc/group | sort -n | uniq -c | while read x ; do
-                    [ -z "$x" ] && break
-                    set - $x
-                    if [ $1 -gt 1 ]; then
-                            gids=$(gawk -F: '($1 == n) { print $3 }' n=$2 /etc/group | xargs)
-                            echo "Duplicate Group Name ($2): $gids"
-                    fi
-                    done
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Based on the results of the audit script, establish unique names for the user groups. File group ownerships will automatically reflect the change as long as the groups have unique GIDs.
-      scored: true                  
+        scored: true
 
-    - id: 6.2.20.a
-      description: "Ensure shadow group is empty"
-      audit: "grep ^shadow:[^:]*:[^:]*:[^:]+ /etc/group"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Remove all users from the shadow group, and change the primary group of any users with shadow as their primary group.
-      scored: true                  
-            
-    - id: 6.2.20.b
-      description: "Ensure shadow group is empty"
-      audit: "awk -F: '($4 == \"\") { print }' /etc/passwd"   
-      tests:
-        test_items:
-        - flag: ""
-          compare:
-            op: eq
-            value: ""
-          set: true                        
-      remediation: |
-            Remove all users from the shadow group, and change the primary group of any users with shadow as their primary group.
-      scored: true                  
- 
+      - id: 6.1.10.a
+        description: "Ensure no world writable files exist"
+        audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002 | head -n 100"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Removing write access for the "other" category ( `chmod o-w ` ) is advisable, but always consult relevant vendor documentation to avoid breaking any application dependencies on a given file.
+        scored: true
+
+      - id: 6.1.10.b
+        description: "Ensure no world writable files exist"
+        audit: "find <partition> -xdev -type f -perm -0002 "
+        type: manual
+        remediation: |
+          Removing write access for the "other" category ( `chmod o-w ` ) is advisable, but always consult relevant vendor documentation to avoid breaking any application dependencies on a given file.
+        scored: true
+
+      - id: 6.1.11.a
+        description: "Ensure no unowned files or directories exist"
+        audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser | head -n 100"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
+        scored: true
+
+      - id: 6.1.11.b
+        description: "Ensure no unowned files or directories exist"
+        audit: "find <partition> -xdev -type f -perm -0002"
+        type: manual
+        remediation: |
+          Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
+        scored: true
+
+      - id: 6.1.12.a
+        description: "Ensure no ungrouped files or directories exist"
+        audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup | head -n 100"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
+        scored: true
+
+      - id: 6.1.12.b
+        description: "Ensure no ungrouped files or directories exist"
+        audit: "find <partition> -xdev -nogroup"
+        type: manual
+        remediation: |
+          Locate files that are owned by users or groups not listed in the system configuration files, and reset the ownership of these files to some active user on the system as appropriate.
+        scored: true
+
+      - id: 6.1.13.a
+        description: "Audit SUID executables"
+        audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -4000 | head -n 100"
+        type: manual
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Ensure that no rogue SUID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
+        scored: false
+
+      - id: 6.1.13.b
+        description: "Audit SUID executables"
+        audit: "find <partition> -xdev -type f -perm -4000"
+        type: manual
+        remediation: |
+          Ensure that no rogue SUID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
+        scored: false
+
+      - id: 6.1.14.a
+        description: "Audit SGID executables"
+        audit: "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -2000 | head -n 100"
+        type: manual
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Ensure that no rogue SGID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
+        scored: false
+
+      - id: 6.1.14.b
+        description: "Audit SGID executables"
+        audit: "find <partition> -xdev -type f -perm -2000"
+        type: manual
+        remediation: |
+          Ensure that no rogue SGID programs have been introduced into the system. Review the files returned by the action in the Audit section and confirm the integrity of these binaries.
+        scored: false
+
+  - id: 6.2
+    description: "User and Group Settings"
+    checks:
+      - id: 6.2.1
+        description: "Ensure password fields are not empty"
+        audit: 'awk -F: ''($2 == "" ) { print $1 " does not have a password "}'' /etc/shadow'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          If any accounts in the /etc/shadow file do not have a password, run the following command
+          to lock the account until it can be determined why it does not have a password:
+          # passwd -l <username>
+          Also, check to see if the account is logged in and investigate what it is being used for to
+          determine if it needs to be forced off.
+        scored: true
+
+      - id: 6.2.2
+        description: 'Ensure no legacy "+" entries exist in /etc/passwd'
+        audit: "grep '^\\+:' /etc/passwd"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Remove any legacy '+' entries from `/etc/passwd` if they exist.
+        scored: true
+
+      - id: 6.2.3
+        description: 'Ensure no legacy "+" entries exist in /etc/shadow'
+        audit: "grep '^\\+:' /etc/shadow"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Remove any legacy '+' entries from `/etc/shadow` if they exist.
+        scored: true
+
+      - id: 6.2.4
+        description: 'Ensure no legacy "+" entries exist in /etc/group'
+        audit: "grep '^\\+:' /etc/group"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Remove any legacy '+' entries from `/etc/group` if they exist.
+        scored: true
+
+      - id: 6.2.5
+        description: "Ensure root is the only UID 0 account"
+        audit: "awk -F: '($3 == 0) { print $1 }' /etc/passwd"
+        tests:
+          test_items:
+            - flag: "root"
+              set: true
+        remediation: |
+          Remove any users other than `root` with UID `0` or assign them a new UID if appropriate.
+        scored: true
+
+      - id: 6.2.6
+        description: "Ensure root PATH Integrity"
+        audit: |
+          #!/bin/bash
+          if [ "$(echo "$PATH" | grep ::)" != "" ]; then
+                  echo "Empty Directory in PATH (::)"
+          fi
+
+          if [ "$(echo "$PATH" | grep :$)" != "" ]; then
+                  echo "Trailing : in PATH"
+          fi
+
+          p=$(echo "$PATH" | sed -e 's/::/:/' -e 's/:$//' -e 's/:/ /g')
+          set -- $p
+          while [ "$1" != "" ]; do
+                  if [ "$1" = "." ]; then
+                          shift
+                          continue
+                  fi
+                  if [ -d "$1" ]; then
+                          dirperm=$(ls -ldH "$1" | cut -f1 -d" ")
+                          if [ "$(echo "$dirperm" | cut -c6)" != "-" ]; then
+                                  echo "Group Write permission set on directory $1"
+                          fi
+                          if [ "$(echo "$dirperm" | cut -c9)" != "-" ]; then
+                                  echo "Other Write permission set on directory $1"
+                          fi
+                          dirown=$(ls -ldH "$1" | awk '{print $3}')
+                          if [ "$dirown" != "root" ] ; then
+                                  echo "$1 is not owned by root"
+                          fi
+                  else
+                          echo "$1 is not a directory"
+                  fi
+                  shift
+          done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Correct or justify any items discovered in the Audit step.
+        scored: true
+
+      - id: 6.2.7
+        description: "Ensure all users' home directories exist"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' |
+                  while read -r user dir; do
+                          if [ ! -d "$dir" ]; then
+                                  echo "The home directory ($dir) of user $user does not exist."
+                          fi
+                  done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          If any users' home directories do not exist, create them and make sure the respective user owns the directory. Users without an assigned home directory should be removed or assigned a home directory as appropriate.
+        scored: true
+
+      - id: 6.2.8
+        description: "Ensure users' home directories permissions are 750 or more restrictive"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' |
+          while read user dir; do
+              if [ ! -d "$dir" ]; then
+                  echo "The home directory ($dir) of user $user does not exist."
+              else
+                  dirperm=$(ls -ld $dir | cut -f1 -d" ")
+                  if [ $(echo $dirperm | cut -c6) != "-" ]; then
+                      echo "Group Write permission set on the home directory ($dir) of user $user"
+                  fi
+                  if [ $(echo $dirperm | cut -c8) != "-" ]; then
+                      echo "Other Read permission set on the home directory ($dir) of user $user"
+                  fi
+                  if [ $(echo $dirperm | cut -c9) != "-" ]; then
+                      echo "Other Write permission set on the home directory ($dir) of user $user"
+                  fi
+                  if [ $(echo $dirperm | cut -c10) != "-" ]; then
+                      echo "Other Execute permission set on the home directory ($dir) of user $user"
+                  fi
+              fi
+          done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Making global modifications to user home directories without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user file permissions and determine the action to be taken in accordance with site policy.
+        scored: true
+
+      - id: 6.2.9
+        description: "Ensure users own their home directories"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+                  if [ ! -d "$dir" ]; then
+                          echo "The home directory ($dir) of user $user does not exist."
+                  else
+                  owner=$(stat -L -c "%U" "$dir")
+                          if [ "$owner" != "$user" ]; then
+                          echo "The home directory ($dir) of user $user is owned by $owner."
+                          fi
+                  fi
+          done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Change the ownership of any home directories that are not owned by the defined user to the correct user.
+        scored: true
+
+      - id: 6.2.10
+        description: "Ensure users' dot files are not group or world writable"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+                  if [ ! -d "$dir" ]; then
+                          echo "The home directory ($dir) of user $user does not exist."
+                  else
+                          for file in $dir/.[A-Za-z0-9]*; do
+                                  if [ ! -h "$file" -a -f "$file" ]; then
+                                          fileperm=$(ls -ld $file | cut -f1 -d" ")
+                                                  if [ $(echo $fileperm | cut -c6) != "-" ]; then
+                                                          echo "Group Write permission set on file $file"
+                                                  fi
+                                                  if [ $(echo $fileperm | cut -c9) != "-" ]; then
+                                                          echo "Other Write permission set on file $file"
+                                          fi
+                                  fi
+                          done
+                  fi
+          done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user dot file permissions and determine the action to be taken in accordance with site policy.
+        scored: true
+
+      - id: 6.2.11
+        description: "Ensure no users have .forward files"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+                  if [ ! -d "$dir" ]; then
+                          echo "The home directory ($dir) of user $user does not exist."
+                  else
+                          if [ ! -h "$dir/.forward" -a -f "$dir/.forward" ]; then
+                                  echo ".forward file $dir/.forward exists"
+                          fi
+                  fi
+          done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.forward` files and determine the action to be taken in accordance with site policy.
+        scored: true
+
+      - id: 6.2.12
+        description: "Ensure no users have .netrc files"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+                  if [ ! -d "$dir" ]; then
+                          echo "The home directory ($dir) of user $user does not exist."
+                  else
+                          if [ ! -h "$dir/.netrc" -a -f "$dir/.netrc" ]; then
+                                  echo ".netrc file $dir/.netrc exists"
+                          fi
+                  fi
+          done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.netrc` files and determine the action to be taken in accordance with site policy.
+        scored: true
+
+      - id: 6.2.13
+        description: "Ensure users' .netrc Files are not group or world accessible"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+          if [ ! -d "$dir" ]; then
+                  echo "The home directory ($dir) of user $user does not exist."
+          else
+                  for file in $dir/.netrc; do
+                          if [ ! -h "$file" -a -f "$file" ]; then
+                                  fileperm=$(ls -ld $file | cut -f1 -d" ")
+                                  if [ $(echo $fileperm | cut -c5) != "-" ]; then
+                                          echo "Group Read set on $file"
+                                  fi
+                                  if [ $(echo $fileperm | cut -c6) != "-" ]; then
+                                          echo "Group Write set on $file"
+                                  fi
+                                  if [ $(echo $fileperm | cut -c7) != "-" ]; then
+                                          echo "Group Execute set on $file"
+                                  fi
+                                  if [ $(echo $fileperm | cut -c8) != "-" ]; then
+                                          echo "Other Read set on $file"
+                                  fi
+                                  if [ $(echo $fileperm | cut -c9) != "-" ]; then
+                                          echo "Other Write set on $file"
+                                  fi
+                                  if [ $(echo $fileperm | cut -c10) != "-" ]; then
+                                          echo "Other Execute set on $file"
+                                  fi
+                          fi
+                  done
+          fi
+          done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.netrc` file permissions and determine the action to be taken in accordance with site policy.
+        scored: true
+
+      - id: 6.2.14
+        description: "Ensure no users have .rhosts files"
+        audit: |
+          #!/bin/bash
+          grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+          if [ ! -d "$dir" ]; then
+                  echo "The home directory ($dir) of user $user does not exist."
+          else
+                  for file in $dir/.rhosts; do
+                          if [ ! -h "$file" -a -f "$file" ]; then
+                                  echo ".rhosts file in $dir"
+                          fi
+                  done
+          fi
+          done
+
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Making global modifications to users' files without alerting the user community can result in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring policy be established to report user `.rhosts` files and determine the action to be taken in accordance with site policy.
+        scored: true
+
+      - id: 6.2.15
+        description: "Ensure all groups in /etc/passwd exist in /etc/group"
+        audit: |
+          #!/bin/bash
+          for i in $(cut -s -d: -f4 /etc/passwd | sort -u ); do
+                  grep -q -P "^.*?:[^:]*:$i:" /etc/group
+                  if [ $? -ne 0 ]; then
+                          echo "Group $i is referenced by /etc/passwd but does not exist in /etc/group"
+                  fi
+          done
+
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Analyze the output of the Audit step above and perform the appropriate action to correct any discrepancies found.
+        scored: true
+
+      - id: 6.2.16
+        description: "Ensure no duplicate UIDs exist"
+        audit: |
+          #!/bin/bash
+          cut -f3 -d":" /etc/passwd | sort -n | uniq -c | while read x ; do
+                  [ -z "$x" ] && break
+                  set - $x
+                  if [ $1 -gt 1 ]; then
+                          users=$(awk -F: '($3 == n) { print $1 }' n=$2 /etc/passwd | xargs)
+                          echo "Duplicate UID ($2): $users"
+                  fi
+                  done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Based on the results of the audit script, establish unique UIDs and review all files owned by the shared UIDs to determine which UID they are supposed to belong to.
+        scored: true
+
+      - id: 6.2.17
+        description: "Ensure no duplicate GIDs exist"
+        audit: |
+          #!/bin/bash
+          cut -f3 -d":" /etc/group | sort -n | uniq -c | while read x ; do
+          [ -z "$x" ] && break
+          set - $x
+          if [ $1 -gt 1 ]; then
+                  groups=$(awk -F: '($3 == n) { print $1 }' n=$2 /etc/group | xargs)
+                  echo "Duplicate GID ($2): $groups"
+          fi
+          done
+
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Based on the results of the audit script, establish unique GIDs and review all files owned by the shared GID to determine which group they are supposed to belong to.
+        scored: true
+
+      - id: 6.2.18
+        description: "Ensure no duplicate user names exist"
+        audit: |
+          #!/bin/bash
+          cut -f1 -d":" /etc/passwd | sort -n | uniq -c | while read x ; do
+                  [ -z "$x" ] && break
+                  set - $x
+                  if [ $1 -gt 1 ]; then
+                          uids=$(awk -F: '($1 == n) { print $3 }' n=$2 /etc/passwd | xargs)
+                          echo "Duplicate User Name ($2): $uids"
+                  fi
+                  done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Based on the results of the audit script, establish unique user names for the users. File ownerships will automatically reflect the change as long as the users have unique UIDs.
+        scored: true
+
+      - id: 6.2.19
+        description: "Ensure no duplicate group names exist"
+        audit: |
+          #!/bin/bash
+          cut -f1 -d":" /etc/group | sort -n | uniq -c | while read x ; do
+                  [ -z "$x" ] && break
+                  set - $x
+                  if [ $1 -gt 1 ]; then
+                          gids=$(gawk -F: '($1 == n) { print $3 }' n=$2 /etc/group | xargs)
+                          echo "Duplicate Group Name ($2): $gids"
+                  fi
+                  done
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Based on the results of the audit script, establish unique names for the user groups. File group ownerships will automatically reflect the change as long as the groups have unique GIDs.
+        scored: true
+
+      - id: 6.2.20.a
+        description: "Ensure shadow group is empty"
+        audit: "grep ^shadow:[^:]*:[^:]*:[^:]+ /etc/group"
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Remove all users from the shadow group, and change the primary group of any users with shadow as their primary group.
+        scored: true
+
+      - id: 6.2.20.b
+        description: "Ensure shadow group is empty"
+        audit: 'awk -F: ''($4 == "") { print }'' /etc/passwd'
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: |
+          Remove all users from the shadow group, and change the primary group of any users with shadow as their primary group.
+        scored: true

--- a/hack/test-definitions/definitions.yaml
+++ b/hack/test-definitions/definitions.yaml
@@ -1,0 +1,35 @@
+---
+controls:
+version: 0.1
+id: 1
+description: "Test YAMl file"
+type: "hack"
+groups:
+  - id: 1.1
+    description: "Filesystem Configuration"
+    checks:
+      - id: 1.1.1
+        description: "Disable unused filesystems"
+        checks:
+      - id: 1.1.1.1.a
+        description: "Ensure mounting of cramfs filesystems is disabled"
+        audit: "echo hello"
+        tests:
+          test_items:
+            - flag: "hello"
+              set: true
+        remediation: |
+          Correct something about this test
+        scored: true
+      - id: 1.1.1.1.b
+        description: "Ensure mounting of cramfs filesystems is disabled"
+        audit: "echo hello=false"
+        tests:
+          test_items:
+            - flag: "hello"
+              compare:
+                op: eq
+                value: "false"
+              set: true
+        remediation: |
+          Put your remediation here


### PR DESCRIPTION
GitHub actions is [hanging while it attempts to execute an external command](https://github.com/aquasecurity/linux-bench/runs/1588871333?check_suite_focus=true). My guess is that there are controls to try to prevent arbitrary remote code execution. This means that the unit tests no longer attempt to run the defined test YAML, but since they didn't check the results or even notice that the YAML was invalid (#71) I don't think that is crucial (although we should add an integration test that does this). 

Tests can be run in parallel so we shouldn't rely on the state of a global variable that is modified in one test being ready when we run another. This didn't turn out to be the reason for failure, but it's fixed now anyway. 

Also fixing some faulty YAML in 2.0.0 - I ended up doing another PR #71 which covers the YAML issues more completely but hopefully they will be easy to merge